### PR TITLE
Added identification in User-Agent header

### DIFF
--- a/src/Basecamp/BasecampClient.php
+++ b/src/Basecamp/BasecampClient.php
@@ -31,9 +31,9 @@ class BasecampClient extends Client
             'auth_method'   => 'http',
             'token'         => null,
             'username'      => null,
-            'password'      => null
+            'password'      => null,
         );
-        $required = array('user_id', 'auth_method');
+        $required = array('user_id', 'auth_method', 'app_name', 'app_contact');
         $config = Collection::fromConfig($config, $default, $required);
         $client = new self($config->get('base_url'), $config);
 
@@ -57,8 +57,12 @@ class BasecampClient extends Client
         $description = ServiceDescription::factory(__DIR__ . '/Resources/service.php');
         $client->setDescription($description);
 
+        // Set required User-Agent
+        $client->setUserAgent(sprintf('%s (%s)', $config['app_name'], $config['app_contact']));
+
         $client->getEventDispatcher()->addListener('request.before_send', function(Event $event) use ($authoritzation) {
             $event['request']->addHeader('Authorization', $authoritzation);
+
         });
 
         return $client;

--- a/tests/Basecamp/Test/BasecampClientTest.php
+++ b/tests/Basecamp/Test/BasecampClientTest.php
@@ -17,11 +17,13 @@ class BasecampClientTest extends \Guzzle\Tests\GuzzleTestCase
     public function testFactoryInitializesClient()
     {
         $client = BasecampClient::factory(array(
-            'auth'     => 'http',
-            'username' => 'foo',
-            'password' => 'bar',
-            'user_id'  => '999999999',
-            'version'  => 'v2'
+            'auth'          => 'http',
+            'username'      => 'foo',
+            'password'      => 'bar',
+            'user_id'       => '999999999',
+            'version'       => 'v2',
+            'app_name'      => 'Fake',
+            'app_contact'   => 'test@fake.com'
         ));
         $this->assertEquals('https://basecamp.com/999999999/api/v2/', $client->getBaseUrl());
     }
@@ -32,10 +34,12 @@ class BasecampClientTest extends \Guzzle\Tests\GuzzleTestCase
     public function testFactoryInitializesClientWithoutAuth()
     {
         $client = BasecampClient::factory(array(
-            'username' => 'foo',
-            'password' => 'bar',
-            'user_id'  => '999999999',
-            'version'  => 'v2'
+            'username'      => 'foo',
+            'password'      => 'bar',
+            'user_id'       => '999999999',
+            'version'       => 'v2',
+            'app_name'      => 'Fake',
+            'app_contact'   => 'test@fake.com'
         ));
     }
 
@@ -45,10 +49,12 @@ class BasecampClientTest extends \Guzzle\Tests\GuzzleTestCase
     public function testFactoryInitializesClientWithoutUserId()
     {
         $client = BasecampClient::factory(array(
-            'auth'     => 'http',
-            'username' => 'foo',
-            'password' => 'bar',
-            'version'  => 'v2'
+            'auth'          => 'http',
+            'username'      => 'foo',
+            'password'      => 'bar',
+            'version'       => 'v2',
+            'app_name'      => 'Fake',
+            'app_contact'   => 'test@fake.com'
         ));
     }
 
@@ -58,6 +64,21 @@ class BasecampClientTest extends \Guzzle\Tests\GuzzleTestCase
     public function testFactoryInitializesClientWithoutToken()
     {
         $client = BasecampClient::factory(array(
+            'auth'          => 'oauth',
+            'username'      => 'foo',
+            'password'      => 'bar',
+            'version'       => 'v2',
+            'app_name'      => 'Fake',
+            'app_contact'   => 'test@fake.com'
+        ));
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testFactoryInitializesClientWithoutIdentification()
+    {
+        $client = BasecampClient::factory(array(
             'auth'     => 'oauth',
             'username' => 'foo',
             'password' => 'bar',
@@ -65,13 +86,31 @@ class BasecampClientTest extends \Guzzle\Tests\GuzzleTestCase
         ));
     }
 
+    public function testFactoryInitializesClientWithIdentification()
+    {
+        $client = BasecampClient::factory(array(
+            'auth'          => 'oauth',
+            'username'      => 'foo',
+            'password'      => 'bar',
+            'version'       => 'v2',
+            'user_id'       => '999999999',
+            'app_name'      => 'Fake',
+            'app_contact'   => 'test@fake.com'
+        ));
+
+        $request = $client->get();
+        $this->assertEquals('Fake (test@fake.com)', (string) $request->getHeader('User-Agent'));
+    }
+
     public function testFactoryInitializesClientWithToken()
     {
         $client = BasecampClient::factory(array(
-            'auth'     => 'oauth',
-            'token'    => 'foo',
-            'version'  => 'v2',
-            'user_id'  => '999999999',
+            'auth'          => 'oauth',
+            'token'         => 'foo',
+            'version'       => 'v2',
+            'user_id'       => '999999999',
+            'app_name'      => 'Fake',
+            'app_contact'   => 'test@fake.com'
         ));
         $this->assertEquals('https://basecamp.com/999999999/api/v2/', $client->getBaseUrl());
     }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -22,10 +22,12 @@ Guzzle\Tests\GuzzleTestCase::setServiceBuilder(Guzzle\Service\Builder\ServiceBui
     'basecamp' => array(
         'class' => 'Basecamp\BasecampClient',
         'params' => array(
-            'auth'     => 'http',
-            'username' => 'test_user',
-            'password' => '****',
-            'user_id'  => '99999999'
+            'auth'          => 'http',
+            'username'      => 'test_user',
+            'password'      => '****',
+            'user_id'       => '99999999',
+            'app_name'      => 'Basecamp PHP Test',
+            'app_contact'   => 'https://github.com/netvlies/basecamp-php'
         )
     )
 )));


### PR DESCRIPTION
Added identification options. Made them required as stated by Basecamp.

Closes https://github.com/netvlies/basecamp-php/issues/1
