### PR TITLE
Replace double-quotes with single-quotes in service.php

### DIFF
--- a/src/Basecamp/Resources/service.php
+++ b/src/Basecamp/Resources/service.php
@@ -105,14 +105,14 @@ return array(
                     'description' => 'Project id',
                     'required' => true
                 ),
-                "name" => array(
-                    "location" => "json",
-                    "type" => "string",
+                'name' => array(
+                    'location' => 'json',
+                    'type' => 'string',
                     'required' => true,
                 ),
-                "description" => array(
-                    "location" => "json",
-                    "type" => "string",
+                'description' => array(
+                    'location' => 'json',
+                    'type' => 'string',
                     'required' => true,
                 )
             )
@@ -131,9 +131,9 @@ return array(
                     'description' => 'Todo list id',
                     'required' => true
                 ),
-                "content" => array(
-                    "location" => "json",
-                    "type" => "string",
+                'content' => array(
+                    'location' => 'json',
+                    'type' => 'string',
                     'required' => true,
                 ),
             )
@@ -152,15 +152,15 @@ return array(
                     'description' => 'Todo id',
                     'required' => true
                 ),
-                "content" => array(
-                    "location" => "json",
-                    "type" => "string",
+                'content' => array(
+                    'location' => 'json',
+                    'type' => 'string',
                     'required' => true,
                 ),
-                "attachments" => array(
-                    "location" => "json",
-                    "type" => "array",
-                    "required" => false,
+                'attachments' => array(
+                    'location' => 'json',
+                    'type' => 'array',
+                    'required' => false,
                 ),
             )
         ),


### PR DESCRIPTION
PHP parses double-quotes for variables, adding a slight overhead to string processing. When variables are not present, single-quotes should be prefered
