### PR TITLE
Add API documentation. Add script for generating API docs from service.php

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Upon creating the client you have to pass your credentials or an OAuth token. Fu
 ```php
 <?php
 
-$service = \Basecamp\BasecampClient::factory(array(
+$client = \Basecamp\BasecampClient::factory(array(
     'auth' => 'http',
     'username' => 'you@email.com',
     'password' => 'secret',
@@ -38,7 +38,7 @@ This library doesn't handle the OAuth authorization process for you. There are a
 ```php
 <?php
 
-$service = \Basecamp\BasecampClient::factory(array(
+$client = \Basecamp\BasecampClient::factory(array(
     'auth'     => 'oauth',
     'token'    => 'Wtj4htewhtuewhuoitewh',
     'user_id'   => 99999999,
@@ -84,35 +84,231 @@ $this->client->addSubscriber($cachePlugin);
 
 ## API calls
 
-Currently only a few example calls have been documented. Refer to the service description (<code>src/Basecamp/Resources/service.php</code>) for all the available calls.
+All services are documented below. View full service description in [src/Basecamp/Resources/service.php][service.php]
 
-### Get a project
+<!--- START API Generate with: php -f `generate-api-docs.php` -->
 
-```php
-<?php
+### Get archived Projects
+[Basecamp API: Projects](https://github.com/basecamp/bcx-api/blob/master/sections/projects.md) 
 
-$project = $client->getProject(array(
-    'projectId' => 1
-));
+```php 
+$response = $client->getArchivedProjects(); 
+``` 
 
-```
+### Get active Projects
+[Basecamp API: Projects](https://github.com/basecamp/bcx-api/blob/master/sections/projects.md) 
 
-### Get documents
+```php 
+$response = $client->getProjects(); 
+``` 
 
-```php
-<?php
+### Get a Project
+[Basecamp API: Projects](https://github.com/basecamp/bcx-api/blob/master/sections/projects.md) 
 
-$documents = $client->getDocumentsByProject(array(
-    'projectId' => 1
-));
+```php 
+$response = $client->getProject( array( 
+	'id' => 1234567,  // Required. Project ID 
+) ); 
+``` 
 
-$document = $client->getDocument(array(
-    'projectId' => 1,
-    'documentId' => 1
-));
+### Get all Documents
+[Basecamp API: Documents](https://github.com/basecamp/bcx-api/blob/master/sections/documents.md) 
 
-```
+```php 
+$response = $client->getDocumentsByProject( array( 
+	'projectId' => 1234567,  // Required. Project ID 
+) ); 
+``` 
+
+### Get a Document
+[Basecamp API: Documents](https://github.com/basecamp/bcx-api/blob/master/sections/documents.md) 
+
+```php 
+$response = $client->getDocument( array( 
+	'projectId' => 1234567,  // Required. Project ID 
+	'documentId' => 1234567,  // Required. Document ID 
+) ); 
+``` 
+
+### Get Topics
+[Basecamp API: Topics](https://github.com/basecamp/bcx-api/blob/master/sections/topics.md) 
+
+```php 
+$response = $client->getTopicsByProject( array( 
+	'projectId' => 1234567,  // Required. Project ID 
+) ); 
+``` 
+
+### Get Todo Lists
+[Basecamp API: Todo lists](https://github.com/basecamp/bcx-api/blob/master/sections/todolists.md) 
+
+```php 
+$response = $client->getTodolistsByProject( array( 
+	'projectId' => 1234567,  // Required. Project ID 
+) ); 
+``` 
+
+### Get Todo Lists assigned to a Person
+[Basecamp API: Todo lists](https://github.com/basecamp/bcx-api/blob/master/sections/todolists.md) 
+
+```php 
+$response = $client->getAssignedTodolistsByPerson( array( 
+	'personId' => 1234567,  // Required. Person id 
+) ); 
+``` 
+
+### Get completed Todo Lists
+[Basecamp API: Todo lists](https://github.com/basecamp/bcx-api/blob/master/sections/todolists.md) 
+
+```php 
+$response = $client->getCompletedTodolistsByProject( array( 
+	'projectId' => 1234567,  // Required. Project id 
+) ); 
+``` 
+
+### Create Todo List
+[Basecamp API: Todo lists](https://github.com/basecamp/bcx-api/blob/master/sections/todolists.md) 
+
+```php 
+$response = $client->createTodolistByProject( array( 
+	'projectId' => 1234567,  // Required. Project id 
+	'name' => 'Example name',  // Required.  
+	'description' => 'Example description',  // Required.  
+) ); 
+``` 
+
+### Create Todo
+[Basecamp API: Todos](https://github.com/basecamp/bcx-api/blob/master/sections/todos.md) 
+
+```php 
+$response = $client->createTodoByTodolist( array( 
+	'projectId' => 1234567,  // Required. Project id 
+	'todolistId' => 1234567,  // Required. Todo list id 
+	'content' => 'Example content',  // Required.  
+	'assignee' => array( 'id' => 1234567, 'type' => 'Person' ),  // Optional.  
+) ); 
+``` 
+
+### Create Comment on Todo
+[Basecamp API: Comments](https://github.com/basecamp/bcx-api/blob/master/sections/comments.md) 
+
+```php 
+$response = $client->createCommentByTodo( array( 
+	'projectId' => 1234567,  // Required. Project id 
+	'todoId' => 1234567,  // Required. Todo id 
+	'content' => 'Example content',  // Required.  
+	'attachments' => array( array( 'token' => $upload_token, 'name' => 'file.jpg' ) ),  // Optional.  
+) ); 
+``` 
+
+### Get Attachments
+[Basecamp API: Attachments](https://github.com/basecamp/bcx-api/blob/master/sections/attachments.md) 
+
+```php 
+$response = $client->getAttachmentsByProject( array( 
+	'projectId' => 1234567,  // Required. Project id 
+) ); 
+``` 
+
+### Create Attachment
+[Basecamp API: Attachments](https://github.com/basecamp/bcx-api/blob/master/sections/attachments.md) 
+
+```php 
+$response = $client->createAttachment( array( 
+	'mimeType' => 'image/jpeg',  // Required. The content type of the data 
+	'data' => file_get_contents( 'image.jpg' ),  // Required. The attachment's binary data 
+) ); 
+``` 
+
+### Get Todo List
+[Basecamp API: Todo lists](https://github.com/basecamp/bcx-api/blob/master/sections/todolists.md) 
+
+```php 
+$response = $client->getTodolist( array( 
+	'projectId' => 1234567,  // Required. Project id 
+	'todolistId' => 1234567,  // Required. Todolist id 
+) ); 
+``` 
+
+### Get Todo
+[Basecamp API: Todos](https://github.com/basecamp/bcx-api/blob/master/sections/todos.md) 
+
+```php 
+$response = $client->getTodo( array( 
+	'projectId' => 1234567,  // Required. Project id 
+	'todoId' => 1234567,  // Required. Todo id 
+) ); 
+``` 
+
+### Update Todo
+[Basecamp API: Todos](https://github.com/basecamp/bcx-api/blob/master/sections/todos.md) 
+
+```php 
+$response = $client->updateTodo( array( 
+	'projectId' => 1234567,  // Required. Project id 
+	'todoId' => 1234567,  // Required. Todo id 
+	'content' => 'Example content',  // Optional.  
+	'due_at' => 'example',  // Optional.  
+	'assignee' => array( 'id' => 1234567, 'type' => 'Person' ),  // Optional.  
+	'completed' => 'example',  // Optional.  
+) ); 
+``` 
+
+### Get current User
+[Basecamp API: People](https://github.com/basecamp/bcx-api/blob/master/sections/people.md) 
+
+```php 
+$response = $client->getCurrentUser(); 
+``` 
+
+### Get global Events
+[Basecamp API: Events](https://github.com/basecamp/bcx-api/blob/master/sections/events.md) 
+
+```php 
+$response = $client->getGlobalEvents( array( 
+	'since' => '2012-03-24T11:00:00-06:00',  // Optional. All events since given datetime (format: 2012-03-24T11:00:00-06:00) 
+	'page' => 1234567,  // Optional. The page to retrieve. API returns 50 events per page. 
+) ); 
+``` 
+
+### Get Project Events
+[Basecamp API: Events](https://github.com/basecamp/bcx-api/blob/master/sections/events.md) 
+
+```php 
+$response = $client->getProjectEvents( array( 
+	'projectId' => 1234567,  // Required. Project id 
+	'since' => '2012-03-24T11:00:00-06:00',  // Optional. All events since given datetime (format: 2012-03-24T11:00:00-06:00) 
+) ); 
+``` 
+
+### Get Accesses to Project
+[Basecamp API: Accesses](https://github.com/basecamp/bcx-api/blob/master/sections/accesses.md) 
+
+```php 
+$response = $client->getAccessesByProject( array( 
+	'projectId' => 1234567,  // Required. Project id 
+) ); 
+``` 
+
+### Get Accesses to Calendar
+[Basecamp API: Accesses](https://github.com/basecamp/bcx-api/blob/master/sections/accesses.md) 
+
+```php 
+$response = $client->getAccessesByCalendar( array( 
+	'calendarId' => 1234567,  // Required. Calendar id 
+) ); 
+``` 
+
+### Get all People
+[Basecamp API: People](https://github.com/basecamp/bcx-api/blob/master/sections/people.md) 
+
+```php 
+$response = $client->getPeople(); 
+``` 
+
+<!--- END API -->
 
 [basecamp]: https://basecamp.com/
 [guzzle]: http://guzzlephp.org/
 [caching]: http://guzzlephp.org/plugins/cache-plugin.html
+[service.php]: https://github.com/netvlies/basecamp-php/blob/master/src/Basecamp/Resources/service.php

--- a/generate-api-docs.php
+++ b/generate-api-docs.php
@@ -1,0 +1,302 @@
+<?php
+/**
+ * Generate API documentation.
+ *
+ * Run in command line with:
+ *     php -f generate-api.docs.php
+ *
+ * Copy output into README.md
+ */
+
+$docs = new Generate_Docs();
+
+$docs->checkSummaries();
+$docs->generate();
+$docs->save();
+
+class Generate_Docs {
+
+	/**
+	 * @link  http://guzzle3.readthedocs.org/webservice-client/guzzle-service-descriptions.html#parameter-schema
+	 * @var  array Guzzle service description.
+	 */
+	protected $service;
+
+	/**
+	 * @var string Generated docs Markdown
+	 */
+	protected $docs_markdown;
+
+	/**
+	 * Readme filename. Converted to full path on __construct()
+	 * 
+	 * @var string
+	 */
+	protected $readme_file = 'README.md';
+
+	/**
+	 * Markers for identifying start and end of API Calls to be replaced in readme file.
+	 *
+	 * @link( http://stackoverflow.com/a/4829998, Triple hyphen for Pandoc compatibility )
+	 * 
+	 * @var string
+	 */
+	protected $start_marker = '<!--- START API Generate with: php -f `generate-api-docs.php` -->';
+	protected $end_marker = '<!--- END API -->';
+
+	protected $tmpl_heading           = "\n### @summary \n\n";
+
+	protected $tmpl_code_block_start  = "```php \n";
+	protected $tmpl_code_block_end    = "``` \n";
+
+	protected $tmpl_method_without_params     = "\$response = \$client->@method(); \n";
+	protected $tmpl_method_with_params_start  = "\$response = \$client->@method( array( \n";
+	protected $tmpl_method_with_params_end    = ") ); \n";
+	protected $tmpl_method_parameter          = "\t'@param' => @example,  // @required @description \n";
+
+	/**
+	 * Parameter code examples in order of priority.
+	 *
+	 * Note the use of single quotes within double quotes
+	 * so that strings will output as valid PHP.
+	 * 
+	 * @var array
+	 */
+	protected $examples = array(
+		// Parameter names
+		'since'       => "'2012-03-24T11:00:00-06:00'",
+		'description' => "'Example description'",
+		'content'     => "'Example content'",
+		'name'        => "'Example name'",
+		'data'        => "file_get_contents( 'image.jpg' )",
+		'mimeType'    => "'image/jpeg'",
+		'attachments' => "array( array( 'token' => \$upload_token, 'name' => 'file.jpg' ) )",
+		'assignee'    => "array( 'id' => 1234567, 'type' => 'Person' )",
+
+		// Parameter types
+		'string'      => "'example'",
+		'integer'     => 1234567,
+	);
+
+	function __construct() {
+		$this->service = require __DIR__ . '/src/Basecamp/Resources/service.php';
+		$this->readme_file = __DIR__ . '/' . $this->readme_file;
+	}
+
+	/**
+	 * Verify that all service operations have summaries set before continuing
+	 */
+	public function checkSummaries() {
+		$need_summaries = array();
+
+		foreach ( $this->service['operations'] as $method => $info ) {
+			if ( ! isset( $info['summary'] ) ) {
+				$need_summaries[] = $method;
+			}
+		}
+
+		if ( ! empty( $need_summaries ) ) {
+
+			echo PHP_EOL;
+			echo 'Please set summaries for all operations to generate docs.' . PHP_EOL;
+			echo 'The following operations are missing a \'summary\' value in service.php:' . PHP_EOL;
+
+			foreach ( $need_summaries as $method ) {
+				echo '	' . $method . PHP_EOL;
+			}
+
+			echo PHP_EOL;
+
+			exit;
+
+		}
+	}
+
+	/**
+	 * Output docs for each service operation in Markdown format.
+	 */
+	public function generate() {
+
+		ob_start();
+
+		foreach ( $this->service['operations'] as $method => $info ) {
+
+			// Add method to info array for more convenient templates
+			$info['method'] = $method;
+
+			// Heading
+			echo $this->template( $this->tmpl_heading, $info );
+
+			// Code Block start
+			echo $this->template( $this->tmpl_code_block_start, $info );
+
+			if ( isset( $info['parameters'] ) ) {
+
+				// Method call (with parameters) start
+				echo $this->template( $this->tmpl_method_with_params_start, $info );
+
+				// Parameters
+				foreach ( $info['parameters'] as $param => $param_info ) {
+					$param_info['param'] = $param;
+					echo $this->template( $this->tmpl_method_parameter, $param_info );
+				}
+
+				// Method call end
+				echo $this->template( $this->tmpl_method_with_params_end, $info );
+
+			}else {
+				
+				// Method call (no parameters)
+				echo $this->template( $this->tmpl_method_without_params, $info );
+
+			}
+
+			// Code Block end
+			echo $this->template( $this->tmpl_code_block_end, $info );
+
+		}
+
+		$this->docs_markdown = ob_get_clean();
+
+		return $this->docs_markdown;
+	}
+
+	public function save() {
+		if ( ! isset( $this->docs_markdown ) ) {
+			echo "\nPlease run \$this->generate() before \$this->save()";
+			exit;
+		}
+
+		if ( ! is_readable( $this->readme_file ) || ! is_writable( $this->readme_file ) ) {
+			echo "\nCould not read or write to readme file. Please check permissions.\n";
+			echo "Readme path: {$this->readme_file}\n\n";
+			exit;
+		}
+
+		$readme = file_get_contents( $this->readme_file );
+
+		$this->insertWithMarkers( $this->readme_file, $this->docs_markdown );
+
+		echo PHP_EOL . basename( $this->readme_file ) . ' updated.' . PHP_EOL . PHP_EOL;
+	}
+
+	/**
+	 * Inserts an array of strings into a file (.htaccess ), placing it between
+	 * BEGIN and END markers. Replaces existing marked info. Retains surrounding
+	 * data. Creates file if none exists.
+	 *
+	 * @author  Unknown. Adapted from WordPress core.
+	 * 
+	 * @param string $filename
+	 * @param string $marker
+	 * @param string|array $insertion
+	 * @return bool True on write success, false on failure.
+	 */
+	function insertWithMarkers( $filename, $insertion ) {
+
+		if ( ! is_array( $insertion ) ) {
+			$insertion = explode( "\n", $insertion );
+		}
+
+		if ( ! file_exists( $filename ) || is_writable( $filename ) ) {
+			if ( ! file_exists( $filename ) ) {
+				$markerdata = '';
+			} else {
+				$markerdata = explode( "\n", implode( '', file( $filename ) ) );
+			}
+
+			if ( !$f = @fopen( $filename, 'w' ) )
+				return false;
+
+			$foundit = false;
+			if ( $markerdata ) {
+
+				$state = true;
+
+				foreach ( $markerdata as $n => $markerline ) {
+					if (strpos($markerline, $this->start_marker) !== false) {
+						$state = false;
+					}
+
+					if ( $state ) {
+						if ( $n + 1 < count( $markerdata ) )
+							fwrite( $f, "{$markerline}\n" );
+						else
+							fwrite( $f, "{$markerline}" );
+					}
+
+					if ( strpos( $markerline, $this->end_marker ) !== false) {
+						fwrite( $f, $this->start_marker . "\n" );
+
+						if ( is_array( $insertion ) ) {
+							foreach ( $insertion as $insertline ) {
+								fwrite( $f, "{$insertline}\n" );
+							}
+						}
+
+						fwrite( $f, $this->end_marker . "\n" );
+						$state = true;
+						$foundit = true;
+					}
+				}
+			}
+			if ( ! $foundit ) {
+				fwrite( $f, "\n" . $this->start_marker . "\n" );
+				foreach ( $insertion as $insertline ) {
+					fwrite( $f, "{$insertline}\n" );
+				}
+				fwrite( $f, $this->end_marker . "\n" );
+			}
+
+			fclose( $f );
+			return true;
+
+		}
+
+		return false;
+
+	}
+
+	/**
+	 * Replace @variables with values in template string.
+	 * 
+	 * @param  string $string Template string. @variable used for variables.
+	 * @param  array $args   Array with keys as variable name, values as value
+	 * @return string
+	 */
+	protected function template( $string, array $args ) {
+
+		// Example data formats
+		$string = str_replace( '@example', $this->getExample( $args ), $string );
+
+		// Required or Optional
+		$string = str_replace( '@required', ( empty( $args['required'] ) ? 'Optional.' : 'Required.' ), $string );
+
+		// Vars from passed array
+		foreach ( $args as $key => $value ) {
+			if ( is_string( $value ) ) {
+				$string = str_replace( '@' . $key, $value, $string );
+			}
+		}
+
+		// Clear remaining variables
+		$string = preg_replace( '/@[a-zA-Z0-9]+/', '', $string );
+
+		return $string;
+	}
+
+	protected function getExample( array $args ) {
+		if ( ! isset( $args['param'] ) ) {
+			return false;
+		}
+
+		foreach ( $this->examples as $key => $code ) {
+			if ( $key == $args['param'] || $key == @ $args['type'] ) {
+				return $code;
+			} 
+		}
+
+		return "''";
+	}
+
+}

--- a/src/Basecamp/Resources/service.php
+++ b/src/Basecamp/Resources/service.php
@@ -7,103 +7,120 @@ return array(
         'getArchivedProjects' => array(
             'httpMethod' => 'GET',
             'uri'       => 'projects/archived.json',
-            'summary'   => 'Get all archived projects'
+            'summary'   => 'Get archived Projects' . PHP_EOL . '[Basecamp API: Projects](https://github.com/basecamp/bcx-api/blob/master/sections/projects.md)',
         ),
         'getProjects' => array(
             'httpMethod' => 'GET',
             'uri'       => 'projects.json',
-            'summary'   => 'Get all active projects'
+            'summary'   => 'Get active Projects' . PHP_EOL . '[Basecamp API: Projects](https://github.com/basecamp/bcx-api/blob/master/sections/projects.md)',
         ),
         'getProject' => array(
             'httpMethod' => 'GET',
             'uri'        => 'projects/{id}.json',
+            'summary'   => 'Get a Project' . PHP_EOL . '[Basecamp API: Projects](https://github.com/basecamp/bcx-api/blob/master/sections/projects.md)',
             'parameters' => array(
                 'id' => array(
                     'location' => 'uri',
-                    'description' => 'Project to retrieve by ID',
-                    'required' => true
+                    'description' => 'Project ID',
+                    'type' => 'integer',
+                    'required' => true,
                 )
             )
         ),
         'getDocumentsByProject' => array(
             'httpMethod' => 'GET',
             'uri' => 'projects/{id}/documents.json',
+            'summary'   => 'Get all Documents' . PHP_EOL . '[Basecamp API: Documents](https://github.com/basecamp/bcx-api/blob/master/sections/documents.md)',
             'parameters' => array(
                 'projectId' => array(
                     'location' => 'uri',
-                    'description' => 'Retrieve documents for given project',
-                    'required' => true
+                    'description' => 'Project ID',
+                    'type' => 'integer',
+                    'required' => true,
                 )
             )
         ),
         'getDocument' => array(
             'httpMethod' => 'GET',
             'uri' => 'projects/{projectId}/documents/{documentId}.json',
+            'summary'   => 'Get a Document' . PHP_EOL . '[Basecamp API: Documents](https://github.com/basecamp/bcx-api/blob/master/sections/documents.md)',
             'parameters' => array(
                 'projectId' => array(
                     'location' => 'uri',
-                    'description' => 'Project id',
-                    'required' => true
+                    'description' => 'Project ID',
+                    'type' => 'integer',
+                    'required' => true,
                 ),
                 'documentId' => array(
                     'location' => 'uri',
-                    'description' => 'Document Id',
-                    'required' => true
+                    'description' => 'Document ID',
+                    'type' => 'integer',
+                    'required' => true,
                 )
             )
         ),
         'getTopicsByProject' => array(
             'httpMethod' => 'GET',
             'uri' => 'projects/{projectId}/topics.json',
+            'summary'   => 'Get Topics' . PHP_EOL . '[Basecamp API: Topics](https://github.com/basecamp/bcx-api/blob/master/sections/topics.md)',
             'parameters' => array(
                 'projectId' => array(
                     'location' => 'uri',
-                    'description' => 'Project id',
-                    'required' => true
+                    'description' => 'Project ID',
+                    'type' => 'integer',
+                    'required' => true,
                 )
             )
         ),
         'getTodolistsByProject' => array(
             'httpMethod' => 'GET',
             'uri' => 'projects/{projectId}/todolists.json',
+            'summary' => 'Get Todo Lists' . PHP_EOL . '[Basecamp API: Todo lists](https://github.com/basecamp/bcx-api/blob/master/sections/todolists.md)',
             'parameters' => array(
                 'projectId' => array(
                     'location' => 'uri',
-                    'description' => 'Project id',
-                    'required' => true
+                    'description' => 'Project ID',
+                    'type' => 'integer',
+                    'required' => true,
                 )
             )
         ),
         'getAssignedTodolistsByPerson' => array(
             'httpMethod' => 'GET',
             'uri' => 'people/{personId}/assigned_todos.json',
+            'summary'   => 'Get Todo Lists assigned to a Person' . PHP_EOL . '[Basecamp API: Todo lists](https://github.com/basecamp/bcx-api/blob/master/sections/todolists.md)',
             'parameters' => array(
                 'personId' => array(
                     'location' => 'uri',
                     'description' => 'Person id',
-                    'required' => true
+                    'type' => 'integer',
+                    'required' => true,
                 )
             )
         ),
         'getCompletedTodolistsByProject' => array(
             'httpMethod' => 'GET',
             'uri' => 'projects/{projectId}/todolists/completed.json',
+            'summary'   => 'Get completed Todo Lists' . PHP_EOL . '[Basecamp API: Todo lists](https://github.com/basecamp/bcx-api/blob/master/sections/todolists.md)',
             'parameters' => array(
                 'projectId' => array(
                     'location' => 'uri',
                     'description' => 'Project id',
-                    'required' => true
+                    'type' => 'integer',
+                    'required' => true,
                 )
             )
         ),
         'createTodolistByProject' => array(
             'httpMethod' => 'POST',
             'uri' => 'projects/{projectId}/todolists.json',
+            'summary'   => 'Create Todo List' . PHP_EOL . '[Basecamp API: Todo lists](https://github.com/basecamp/bcx-api/blob/master/sections/todolists.md)',
             'parameters' => array(
                 'projectId' => array(
                     'location' => 'uri',
                     'description' => 'Project id',
-                    'required' => true
+                    'type' => 'integer',
+                    'required' => true,
                 ),
                 "name" => array(
                     "location" => "json",
@@ -120,16 +137,19 @@ return array(
         'createTodoByTodolist' => array(
             'httpMethod' => 'POST',
             'uri' => 'projects/{projectId}/todolists/{todolistId}/todos.json',
+            'summary'   => 'Create Todo' . PHP_EOL . '[Basecamp API: Todos](https://github.com/basecamp/bcx-api/blob/master/sections/todos.md)',
             'parameters' => array(
                 'projectId' => array(
                     'location' => 'uri',
                     'description' => 'Project id',
-                    'required' => true
+                    'type' => 'integer',
+                    'required' => true,
                 ),
                 'todolistId' => array(
                     'location' => 'uri',
                     'description' => 'Todo list id',
-                    'required' => true
+                    'type' => 'integer',
+                    'required' => true,
                 ),
                 "content" => array(
                     "location" => "json",
@@ -146,16 +166,19 @@ return array(
         'createCommentByTodo' => array(
             'httpMethod' => 'POST',
             'uri' => 'projects/{projectId}/todos/{todoId}/comments.json',
+            'summary'   => 'Create Comment on Todo' . PHP_EOL . '[Basecamp API: Comments](https://github.com/basecamp/bcx-api/blob/master/sections/comments.md)',
             'parameters' => array(
                 'projectId' => array(
                     'location' => 'uri',
                     'description' => 'Project id',
-                    'required' => true
+                    'type' => 'integer',
+                    'required' => true,
                 ),
                 'todoId' => array(
                     'location' => 'uri',
                     'description' => 'Todo id',
-                    'required' => true
+                    'type' => 'integer',
+                    'required' => true,
                 ),
                 "content" => array(
                     "location" => "json",
@@ -172,27 +195,32 @@ return array(
         'getAttachmentsByProject' => array(
             'httpMethod' => 'GET',
             'uri' => 'projects/{projectId}/attachments.json',
+            'summary'   => 'Get Attachments' . PHP_EOL . '[Basecamp API: Attachments](https://github.com/basecamp/bcx-api/blob/master/sections/attachments.md)',
             'parameters' => array(
                 'projectId' => array(
                     'location' => 'uri',
                     'description' => 'Project id',
-                    'required' => true
+                    'type' => 'integer',
+                    'required' => true,
                 )
             )
         ),
         'createAttachment' => array(
             'httpMethod' => 'POST',
             'uri' => 'attachments.json',
+            'summary'   => 'Create Attachment' . PHP_EOL . '[Basecamp API: Attachments](https://github.com/basecamp/bcx-api/blob/master/sections/attachments.md)',
             'parameters' => array(
                 'mimeType' => array(
                     'location'    => 'header',
                     'sentAs'      => 'Content-Type',
                     'description' => 'The content type of the data',
-                    'required'    => true
+                    'type'        => 'string',
+                    'required'    => true,
                 ),
                 'data' => array(
                     'location'    => 'body',
                     'description' => 'The attachment\'s binary data',
+                    'type'        => 'any',
                     'required'    => true,
                 ),
             )
@@ -200,47 +228,56 @@ return array(
         'getTodolist' => array(
             'httpMethod' => 'GET',
             'uri' => 'projects/{projectId}/todolists/{todolistId}.json',
+            'summary'   => 'Get Todo List' . PHP_EOL . '[Basecamp API: Todo lists](https://github.com/basecamp/bcx-api/blob/master/sections/todolists.md)',
             'parameters' => array(
                 'projectId' => array(
                     'location' => 'uri',
                     'description' => 'Project id',
-                    'required' => true
+                    'type' => 'integer',
+                    'required' => true,
                 ),
                 'todolistId' => array(
                     'location' => 'uri',
                     'description' => 'Todolist id',
-                    'required' => true
+                    'type' => 'integer',
+                    'required' => true,
                 )
             )
         ),
         'getTodo' => array(
             'httpMethod' => 'GET',
             'uri' => 'projects/{projectId}/todos/{todoId}.json',
+            'summary'   => 'Get Todo' . PHP_EOL . '[Basecamp API: Todos](https://github.com/basecamp/bcx-api/blob/master/sections/todos.md)',
             'parameters' => array(
                 'projectId' => array(
                     'location' => 'uri',
                     'description' => 'Project id',
-                    'required' => true
+                    'type' => 'integer',
+                    'required' => true,
                 ),
                 'todoId' => array(
                     'location' => 'uri',
                     'description' => 'Todo id',
-                    'required' => true
+                    'type' => 'integer',
+                    'required' => true,
                 )
             )
         ),
         'updateTodo' => array(
             'httpMethod' => 'PUT',
             'uri' => 'projects/{projectId}/todos/{todoId}.json',
+            'summary'   => 'Update Todo' . PHP_EOL . '[Basecamp API: Todos](https://github.com/basecamp/bcx-api/blob/master/sections/todos.md)',
             'parameters' => array(
                 'projectId' => array(
                     'location' => 'uri',
                     'description' => 'Project id',
+                    'type' => 'integer',
                     'required' => true,
                 ),
                 'todoId' => array(
                     'location' => 'uri',
                     'description' => 'Todo id',
+                    'type' => 'integer',
                     'required' => true,
                 ),
                 'content' => array(
@@ -268,69 +305,76 @@ return array(
         'getCurrentUser' => array(
             'httpMethod' => 'GET',
             'uri' => 'people/me.json',
+            'summary'   => 'Get current User' . PHP_EOL . '[Basecamp API: People](https://github.com/basecamp/bcx-api/blob/master/sections/people.md)',
         ),
         'getGlobalEvents' => array(
             'httpMethod' => 'GET',
             'uri' => 'events.json',
-            'summary' => 'Get all global events',
+            'summary' => 'Get global Events' . PHP_EOL . '[Basecamp API: Events](https://github.com/basecamp/bcx-api/blob/master/sections/events.md)',
             'parameters' => array(
                 'since' => array(
                     'location' => 'query',
                     'description' => 'All events since given datetime (format: 2012-03-24T11:00:00-06:00)',
-                    'required' => false
+                    'type' => 'string',
+                    'required' => false,
                 ),
                 'page' => array(
                     'location' => 'query',
-                    'description' => 'The page to retrieve',
-                    'required' => false
+                    'description' => 'The page to retrieve. API returns 50 events per page.',
+                    'type' => 'integer',
+                    'required' => false,
                 )
             )
         ),
         'getProjectEvents' => array(
             'httpMethod' => 'GET',
             'uri' => 'projects/{projectId}/events.json',
-            'summary' => 'Get all the events on the given project',
+            'summary' => 'Get Project Events' . PHP_EOL . '[Basecamp API: Events](https://github.com/basecamp/bcx-api/blob/master/sections/events.md)',
             'parameters' => array(
                 'projectId' => array(
                     'location' => 'uri',
                     'description' => 'Project id',
-                    'required' => true
+                    'type' => 'integer',
+                    'required' => true,
                 ),
                 'since' => array(
                     'location' => 'query',
                     'description' => 'All events since given datetime (format: 2012-03-24T11:00:00-06:00)',
-                    'required' => false
+                    'type' => 'string',
+                    'required' => false,
                 )
             )
         ),
         'getAccessesByProject' => array(
             'httpMethod' => 'GET',
             'uri' => 'projects/{projectId}/accesses.json',
-            'summary' => 'Will return all the people with access to the project',
+            'summary' => 'Get Accesses to Project' . PHP_EOL . '[Basecamp API: Accesses](https://github.com/basecamp/bcx-api/blob/master/sections/accesses.md)',
             'parameters' => array(
                 'projectId' => array(
                     'location' => 'uri',
                     'description' => 'Project id',
-                    'required' => true
+                    'type' => 'integer',
+                    'required' => true,
                 )
             )
         ),
         'getAccessesByCalendar' => array(
             'httpMethod' => 'GET',
             'uri' => 'calendars/{calendarId}/accesses.json',
-            'summary' => 'Will return all the people with access to the calendar',
+            'summary' => 'Get Accesses to Calendar' . PHP_EOL . '[Basecamp API: Accesses](https://github.com/basecamp/bcx-api/blob/master/sections/accesses.md)',
             'parameters' => array(
                 'calendarId' => array(
                     'location' => 'uri',
                     'description' => 'Calendar id',
-                    'required' => true
+                    'type' => 'integer',
+                    'required' => true,
                 )
             )
         ),
         'getPeople' => array(
             'httpMethod' => 'GET',
             'uri'       => 'people.json',
-            'summary'   => 'Get all people on the account'
+            'summary'   => 'Get all People' . PHP_EOL . '[Basecamp API: People](https://github.com/basecamp/bcx-api/blob/master/sections/people.md)'
         )
     )
 );


### PR DESCRIPTION
- Add summaries and descriptions to service.php
- Add script generate-api-docs.php, which will update API docs between markers based on the code in service.php.
- Run generate-api-docs.php with `php -f generate-api-docs.php`
- Include example PHP values for each type of parameter in generate-api-docs.php.
- Add links to relevant Basecamp API documentation in service.php. Include these when generating section in readme.
- Add link to service.php file in readme.
- Change `$service` in readme authorization example to `$client` to be consistent with API examples.

Sorry, this PR includes the two commits from #20.
