### PR TITLE
Config defaults had auth_method key which was never used

### DIFF
--- a/src/Basecamp/BasecampClient.php
+++ b/src/Basecamp/BasecampClient.php
@@ -28,12 +28,12 @@ class BasecampClient extends Client
         $default = array(
             'base_url'      => 'https://basecamp.com/{user_id}/api/{version}/',
             'version'       => 'v1',
-            'auth_method'   => 'http',
+            'auth'          => 'http',
             'token'         => null,
             'username'      => null,
             'password'      => null,
         );
-        $required = array('user_id', 'auth_method', 'app_name', 'app_contact');
+        $required = array('user_id', 'auth', 'app_name', 'app_contact');
         $config = Collection::fromConfig($config, $default, $required);
         $client = new self($config->get('base_url'), $config);
 

--- a/src/Basecamp/BasecampClient.php
+++ b/src/Basecamp/BasecampClient.php
@@ -33,7 +33,7 @@ class BasecampClient extends Client
             'username'      => null,
             'password'      => null,
         );
-        $required = array('user_id', 'auth', 'app_name', 'app_contact');
+        $required = array('user_id', 'app_name', 'app_contact');
         $config = Collection::fromConfig($config, $default, $required);
         $client = new self($config->get('base_url'), $config);
 

--- a/tests/Basecamp/Test/BasecampClientTest.php
+++ b/tests/Basecamp/Test/BasecampClientTest.php
@@ -31,7 +31,7 @@ class BasecampClientTest extends \Guzzle\Tests\GuzzleTestCase
     /**
      * @expectedException InvalidArgumentException
      */
-    public function testFactoryInitializesClientWithoutAuth()
+    public function testFactoryInitializesClientWithInvalidAuth()
     {
         $client = BasecampClient::factory(array(
             'username'      => 'foo',
@@ -39,7 +39,8 @@ class BasecampClientTest extends \Guzzle\Tests\GuzzleTestCase
             'user_id'       => '999999999',
             'version'       => 'v2',
             'app_name'      => 'Fake',
-            'app_contact'   => 'test@fake.com'
+            'app_contact'   => 'test@fake.com',
+            'auth'          => 'invalid_auth_type'
         ));
     }
 


### PR DESCRIPTION
Changed the default key to `auth` and removed it from the `$required` array. Also updated the unit test to test for an invalid auth rather than no auth, since one will always be set.