### PR TITLE
Add calendar service calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ $response = $client->getProjects();
 
 ```php 
 $response = $client->getProject( array( 
-	'id' => 1234567,  // Required. Project ID 
+    'id' => 1234567,  // Required. Project ID 
 ) ); 
 ``` 
 
@@ -116,7 +116,7 @@ $response = $client->getProject( array(
 
 ```php 
 $response = $client->getDocumentsByProject( array( 
-	'projectId' => 1234567,  // Required. Project ID 
+    'projectId' => 1234567,  // Required. Project ID 
 ) ); 
 ``` 
 
@@ -125,8 +125,8 @@ $response = $client->getDocumentsByProject( array(
 
 ```php 
 $response = $client->getDocument( array( 
-	'projectId' => 1234567,  // Required. Project ID 
-	'documentId' => 1234567,  // Required. Document ID 
+    'projectId' => 1234567,  // Required. Project ID 
+    'documentId' => 1234567,  // Required. Document ID 
 ) ); 
 ``` 
 
@@ -135,7 +135,7 @@ $response = $client->getDocument( array(
 
 ```php 
 $response = $client->getTopicsByProject( array( 
-	'projectId' => 1234567,  // Required. Project ID 
+    'projectId' => 1234567,  // Required. Project ID 
 ) ); 
 ``` 
 
@@ -144,7 +144,7 @@ $response = $client->getTopicsByProject( array(
 
 ```php 
 $response = $client->getTodolistsByProject( array( 
-	'projectId' => 1234567,  // Required. Project ID 
+    'projectId' => 1234567,  // Required. Project ID 
 ) ); 
 ``` 
 
@@ -153,9 +153,9 @@ $response = $client->getTodolistsByProject( array(
 
 ```php 
 $response = $client->getAssignedTodolistsByPerson( array( 
-	'personId' => 1234567,  // Required. Person id
-	'page' => 1234567,  // Optional
-	'due_since' => '2012-03-24T11:00:00-06:00',  // Optional
+    'personId' => 1234567,  // Required. Person id 
+    'page' => 1234567,  // Optional. The page to retrieve. API returns 50 todos per page. 
+    'due_since' => 'example',  // Optional. Will return all the to-do lists with to-dos assigned to the specified person due after the date specified. (format: 2012-03-24T11:00:00-06:00) 
 ) ); 
 ``` 
 
@@ -164,17 +164,28 @@ $response = $client->getAssignedTodolistsByPerson( array(
 
 ```php 
 $response = $client->getCompletedTodolistsByProject( array( 
-	'projectId' => 1234567,  // Required. Project id 
+    'projectId' => 1234567,  // Required. Project id 
 ) ); 
 ``` 
 
-### Create Project
+### Create a new project
 [Basecamp API: Projects](https://github.com/basecamp/bcx-api/blob/master/sections/projects.md) 
 
 ```php 
-$response = $client->createProject( array(
-	'name' => 'Example name',  // Required.  
-	'description' => 'Example description',  // Required.  
+$response = $client->createProject( array( 
+    'name' => 'Example name',  // Required.  
+    'description' => 'Example description',  // Required.  
+) ); 
+``` 
+
+### Create a new document
+[Basecamp API: Documents](https://github.com/basecamp/bcx-api/blob/master/sections/documents.md) 
+
+```php 
+$response = $client->createDocument( array( 
+    'projectId' => 1234567,  // Required. Project ID 
+    'title' => 'example',  // Required.  
+    'content' => 'Example content',  // Required.  
 ) ); 
 ``` 
 
@@ -183,9 +194,9 @@ $response = $client->createProject( array(
 
 ```php 
 $response = $client->createTodolistByProject( array( 
-	'projectId' => 1234567,  // Required. Project id 
-	'name' => 'Example name',  // Required.  
-	'description' => 'Example description',  // Required.  
+    'projectId' => 1234567,  // Required. Project id 
+    'name' => 'Example name',  // Required.  
+    'description' => 'Example description',  // Required.  
 ) ); 
 ``` 
 
@@ -194,10 +205,10 @@ $response = $client->createTodolistByProject( array(
 
 ```php 
 $response = $client->createTodoByTodolist( array( 
-	'projectId' => 1234567,  // Required. Project id 
-	'todolistId' => 1234567,  // Required. Todo list id 
-	'content' => 'Example content',  // Required.  
-	'assignee' => array( 'id' => 1234567, 'type' => 'Person' ),  // Optional.  
+    'projectId' => 1234567,  // Required. Project id 
+    'todolistId' => 1234567,  // Required. Todo list id 
+    'content' => 'Example content',  // Required.  
+    'assignee' => array( 'id' => 1234567, 'type' => 'Person' ),  // Optional.  
 ) ); 
 ``` 
 
@@ -206,21 +217,10 @@ $response = $client->createTodoByTodolist( array(
 
 ```php 
 $response = $client->createCommentByTodo( array( 
-	'projectId' => 1234567,  // Required. Project id 
-	'todoId' => 1234567,  // Required. Todo id 
-	'content' => 'Example content',  // Required.  
-	'attachments' => array( array( 'token' => $upload_token, 'name' => 'file.jpg' ) ),  // Optional.  
-) ); 
-``` 
-
-### Create Document
-[Basecamp API: Documents](https://github.com/basecamp/bcx-api/blob/master/sections/documents.md) 
-
-```php 
-$response = $client->createTodoByTodolist( array( 
-	'projectId' => 1234567,  // Required. Project id 
-    'title' => 'Example title', // Required. Document title 
-	'content' => 'Example content',  // Required.
+    'projectId' => 1234567,  // Required. Project id 
+    'todoId' => 1234567,  // Required. Todo id 
+    'content' => 'Example content',  // Required.  
+    'attachments' => array( array( 'token' => $upload_token, 'name' => 'file.jpg' ) ),  // Optional.  
 ) ); 
 ``` 
 
@@ -229,7 +229,7 @@ $response = $client->createTodoByTodolist( array(
 
 ```php 
 $response = $client->getAttachmentsByProject( array( 
-	'projectId' => 1234567,  // Required. Project id 
+    'projectId' => 1234567,  // Required. Project id 
 ) ); 
 ``` 
 
@@ -238,8 +238,8 @@ $response = $client->getAttachmentsByProject( array(
 
 ```php 
 $response = $client->createAttachment( array( 
-	'mimeType' => 'image/jpeg',  // Required. The content type of the data 
-	'data' => file_get_contents( 'image.jpg' ),  // Required. The attachment's binary data 
+    'mimeType' => 'image/jpeg',  // Required. The content type of the data 
+    'data' => file_get_contents( 'image.jpg' ),  // Required. The attachment's binary data 
 ) ); 
 ``` 
 
@@ -248,8 +248,8 @@ $response = $client->createAttachment( array(
 
 ```php 
 $response = $client->getTodolist( array( 
-	'projectId' => 1234567,  // Required. Project id 
-	'todolistId' => 1234567,  // Required. Todolist id 
+    'projectId' => 1234567,  // Required. Project id 
+    'todolistId' => 1234567,  // Required. Todolist id 
 ) ); 
 ``` 
 
@@ -258,8 +258,8 @@ $response = $client->getTodolist( array(
 
 ```php 
 $response = $client->getTodo( array( 
-	'projectId' => 1234567,  // Required. Project id 
-	'todoId' => 1234567,  // Required. Todo id 
+    'projectId' => 1234567,  // Required. Project id 
+    'todoId' => 1234567,  // Required. Todo id 
 ) ); 
 ``` 
 
@@ -268,12 +268,12 @@ $response = $client->getTodo( array(
 
 ```php 
 $response = $client->updateTodo( array( 
-	'projectId' => 1234567,  // Required. Project id 
-	'todoId' => 1234567,  // Required. Todo id 
-	'content' => 'Example content',  // Optional.  
-	'due_at' => 'example',  // Optional.  
-	'assignee' => array( 'id' => 1234567, 'type' => 'Person' ),  // Optional.  
-	'completed' => 'example',  // Optional.  
+    'projectId' => 1234567,  // Required. Project id 
+    'todoId' => 1234567,  // Required. Todo id 
+    'content' => 'Example content',  // Optional.  
+    'due_at' => 'example',  // Optional.  
+    'assignee' => array( 'id' => 1234567, 'type' => 'Person' ),  // Optional.  
+    'completed' => 'example',  // Optional.  
 ) ); 
 ``` 
 
@@ -289,8 +289,8 @@ $response = $client->getCurrentUser();
 
 ```php 
 $response = $client->getGlobalEvents( array( 
-	'since' => '2012-03-24T11:00:00-06:00',  // Optional. All events since given datetime (format: 2012-03-24T11:00:00-06:00) 
-	'page' => 1234567,  // Optional. The page to retrieve. API returns 50 events per page. 
+    'since' => '2012-03-24T11:00:00-06:00',  // Optional. All events since given datetime (format: 2012-03-24T11:00:00-06:00) 
+    'page' => 1234567,  // Optional. The page to retrieve. API returns 50 events per page. 
 ) ); 
 ``` 
 
@@ -299,8 +299,8 @@ $response = $client->getGlobalEvents( array(
 
 ```php 
 $response = $client->getProjectEvents( array( 
-	'projectId' => 1234567,  // Required. Project id 
-	'since' => '2012-03-24T11:00:00-06:00',  // Optional. All events since given datetime (format: 2012-03-24T11:00:00-06:00) 
+    'projectId' => 1234567,  // Required. Project id 
+    'since' => '2012-03-24T11:00:00-06:00',  // Optional. All events since given datetime (format: 2012-03-24T11:00:00-06:00) 
 ) ); 
 ``` 
 
@@ -309,18 +309,7 @@ $response = $client->getProjectEvents( array(
 
 ```php 
 $response = $client->getAccessesByProject( array( 
-	'projectId' => 1234567,  // Required. Project id 
-) ); 
-``` 
-
-### Grant Access to Project
-[Basecamp API: Accesses](https://github.com/basecamp/bcx-api/blob/master/sections/accesses.md) 
-
-```php 
-$response = $client->grantAccess( array( 
-    'projectId' => 1234567, // Required. Project id
-    'ids' => array(1,2,3), // Required. User ids to grant access to.
-    'email_addresses' => array(you@email.com) // Optional. Grant access to a new user.
+    'projectId' => 1234567,  // Required. Project id 
 ) ); 
 ``` 
 
@@ -329,7 +318,7 @@ $response = $client->grantAccess( array(
 
 ```php 
 $response = $client->getAccessesByCalendar( array( 
-	'calendarId' => 1234567,  // Required. Calendar id 
+    'calendarId' => 1234567,  // Required. Calendar id 
 ) ); 
 ``` 
 
@@ -338,6 +327,228 @@ $response = $client->getAccessesByCalendar( array(
 
 ```php 
 $response = $client->getPeople(); 
+``` 
+
+### Get all Groups
+[Basecamp API: People](https://github.com/basecamp/bcx-api/blob/master/sections/groups.md) 
+
+```php 
+$response = $client->getGroups(); 
+``` 
+
+### Grant access
+[Basecamp API: Access](https://github.com/basecamp/bcx-api/blob/master/sections/accesses.md) 
+
+```php 
+$response = $client->grantAccess( array( 
+    'projectId' => 1234567,  // Required. Project id 
+    'ids' => '',  // Required. Existing user ids 
+    'email_addresses' => 'example',  // Optional. Grant access to new users 
+) ); 
+``` 
+
+### Get all Calendars
+[Basecamp API: Calendars](https://github.com/basecamp/bcx-api/blob/master/sections/calendars.md) 
+
+```php 
+$response = $client->getCalendars(); 
+``` 
+
+### Get single Calendar
+[Basecamp API: Calendars](https://github.com/basecamp/bcx-api/blob/master/sections/calendars.md) 
+
+```php 
+$response = $client->getCalendar( array( 
+    'calendarId' => 1234567,  // Required. Calendar id 
+) ); 
+``` 
+
+### Create new Calendar
+[Basecamp API: Calendars](https://github.com/basecamp/bcx-api/blob/master/sections/calendars.md) 
+
+```php 
+$response = $client->createCalendar( array( 
+    'name' => 'Example name',  // Required.  
+) ); 
+``` 
+
+### Update Calendar
+[Basecamp API: Calendars](https://github.com/basecamp/bcx-api/blob/master/sections/calendars.md) 
+
+```php 
+$response = $client->updateCalendar( array( 
+    'calendarId' => 1234567,  // Required. Calendar id 
+    'name' => 'Example name',  // Required.  
+) ); 
+``` 
+
+### Delete Calendar
+[Basecamp API: Calendars](https://github.com/basecamp/bcx-api/blob/master/sections/calendars.md) 
+
+```php 
+$response = $client->deleteCalendar( array( 
+    'calendarId' => 1234567,  // Required. Calendar id 
+) ); 
+``` 
+
+### Get all events
+[Basecamp API: Calendar Events](https://github.com/basecamp/bcx-api/blob/master/sections/calendar_events.md) 
+
+```php 
+$response = $client->getAllCalendarEvents( array( 
+    'start_date' => 'example',  // Optional. Will return 6 weeks worth of events after the start date if the end date is not supplied (format: 2015-09-15) 
+    'end_date' => 'example',  // Optional. Will return 6 weeks worth of events after the start date if the end date is not supplied (format: 2015-09-15) 
+) ); 
+``` 
+
+### Get upcoming calendar events
+[Basecamp API: Calendar Events](https://github.com/basecamp/bcx-api/blob/master/sections/calendar_events.md) 
+
+```php 
+$response = $client->getCalendarEvents( array( 
+    'calendarId' => 1234567,  // Required. Calendar id 
+    'start_date' => 'example',  // Optional. Will return 6 weeks worth of events after the start date if the end date is not supplied (format: 2015-09-15) 
+    'end_date' => 'example',  // Optional. Will return 6 weeks worth of events after the start date if the end date is not supplied (format: 2015-09-15) 
+) ); 
+``` 
+
+### Get past calendar events
+[Basecamp API: Calendar Events](https://github.com/basecamp/bcx-api/blob/master/sections/calendar_events.md) 
+
+```php 
+$response = $client->getCalendarEventsPast( array( 
+    'calendarId' => 1234567,  // Required. Calendar id 
+) ); 
+``` 
+
+### Get single calendar event
+[Basecamp API: Calendar Events](https://github.com/basecamp/bcx-api/blob/master/sections/calendar_events.md) 
+
+```php 
+$response = $client->getCalendarEvent( array( 
+    'calendarId' => 1234567,  // Required. Calendar id 
+    'eventId' => 1234567,  // Required. Event id 
+) ); 
+``` 
+
+### Create calendar event
+[Basecamp API: Calendar Events](https://github.com/basecamp/bcx-api/blob/master/sections/calendar_events.md) 
+
+```php 
+$response = $client->createCalendarEvent( array( 
+    'calendarId' => 1234567,  // Required. Calendar id 
+    'summary' => 'example',  // Required. Event Summary / title 
+    'description' => 'Example description',  // Optional. Event Description 
+    'starts_at' => 'example',  // Required. Date (and time if not an all day event) that the event starts at (format: 2015-09-15 or 2015-09-15T11:50:00-05:00) 
+    'ends_at' => 'example',  // Optional. Date (and time if not an all day event) that the event ends at (format: 2015-09-15 or 2015-09-15T11:50:00-05:00) 
+    'remind_at' => 'example',  // Optional. Datetime to remind subscribers about the event via email (format: 2015-09-15T11:50:00-05:00) 
+    'subscribers' => '',  // Optional. Array of user id's to subscribe to the event. 
+    'recurring' => '',  // Optional. Array of recurring parrameters - starts_at, frequency, count, until, excluding 
+    'all_day' => '',  // Optional. Is the event a full day event? 
+) ); 
+``` 
+
+### Update a calendar event
+[Basecamp API: Calendar Events](https://github.com/basecamp/bcx-api/blob/master/sections/calendar_events.md) 
+
+```php 
+$response = $client->updateCalendarEvent( array( 
+    'calendarId' => 1234567,  // Required. Calendar id 
+    'eventId' => 1234567,  // Required. Event id 
+    'summary' => 'example',  // Optional. Event Summary / title 
+    'description' => 'Example description',  // Optional. Event Description 
+    'starts_at' => 'example',  // Optional. Date (and time if not an all day event) that the event starts at (format: 2015-09-15 or 2015-09-15T11:50:00-05:00) 
+    'ends_at' => 'example',  // Optional. Date (and time if not an all day event) that the event ends at (format: 2015-09-15 or 2015-09-15T11:50:00-05:00) 
+    'remind_at' => 'example',  // Optional. Datetime to remind subscribers about the event via email (format: 2015-09-15T11:50:00-05:00) 
+    'subscribers' => '',  // Optional. Array of user id's to subscribe to the event. 
+    'recurring' => '',  // Optional. Array of recurring parrameters - starts_at, frequency, count, until, excluding 
+    'all_day' => '',  // Optional. Is the event a full day event? 
+) ); 
+``` 
+
+### Delete a calendar event
+[Basecamp API: Calendar Events](https://github.com/basecamp/bcx-api/blob/master/sections/calendar_events.md) 
+
+```php 
+$response = $client->deleteCalendarEvent( array( 
+    'calendarId' => 1234567,  // Required. Calendar id 
+    'eventId' => 1234567,  // Required. Event id 
+) ); 
+``` 
+
+### Get upcoming project calendar events
+[Basecamp API: Calendar Events](https://github.com/basecamp/bcx-api/blob/master/sections/calendar_events.md) 
+
+```php 
+$response = $client->getProjectCalendarEvents( array( 
+    'projectId' => 1234567,  // Required. Project ID 
+    'start_date' => 'example',  // Optional. Will return 6 weeks worth of events after the start date if the end date is not supplied (format: 2015-09-15) 
+    'end_date' => 'example',  // Optional. Will return 6 weeks worth of events after the start date if the end date is not supplied (format: 2015-09-15) 
+) ); 
+``` 
+
+### Get past project calendar events
+[Basecamp API: Calendar Events](https://github.com/basecamp/bcx-api/blob/master/sections/calendar_events.md) 
+
+```php 
+$response = $client->getProjectCalendarEventsPast( array( 
+    'projectId' => 1234567,  // Required. Project ID 
+) ); 
+``` 
+
+### Get single project calendar event
+[Basecamp API: Calendar Events](https://github.com/basecamp/bcx-api/blob/master/sections/calendar_events.md) 
+
+```php 
+$response = $client->getProjectCalendarEvent( array( 
+    'projectId' => 1234567,  // Required. Project id 
+    'eventId' => 1234567,  // Required. Event id 
+) ); 
+``` 
+
+### Create project calendar event
+[Basecamp API: Calendar Events](https://github.com/basecamp/bcx-api/blob/master/sections/calendar_events.md) 
+
+```php 
+$response = $client->createProjectCalendarEvent( array( 
+    'projectId' => 1234567,  // Required. Project id 
+    'summary' => 'example',  // Required. Event Summary / title 
+    'description' => 'Example description',  // Optional. Event Description 
+    'starts_at' => 'example',  // Required. Date (and time if not an all day event) that the event starts at (format: 2015-09-15 or 2015-09-15T11:50:00-05:00) 
+    'ends_at' => 'example',  // Optional. Date (and time if not an all day event) that the event ends at (format: 2015-09-15 or 2015-09-15T11:50:00-05:00) 
+    'remind_at' => 'example',  // Optional. Datetime to remind subscribers about the event via email (format: 2015-09-15T11:50:00-05:00) 
+    'subscribers' => '',  // Optional. Array of user id's to subscribe to the event. 
+    'recurring' => '',  // Optional. Array of recurring parrameters - starts_at, frequency, count, until, excluding 
+    'all_day' => '',  // Optional. Is the event a full day event? 
+) ); 
+``` 
+
+### Update a project calendar event
+[Basecamp API: Calendar Events](https://github.com/basecamp/bcx-api/blob/master/sections/calendar_events.md) 
+
+```php 
+$response = $client->updateProjectCalendarEvent( array( 
+    'projectId' => 1234567,  // Required. Project id 
+    'eventId' => 1234567,  // Required. Event id 
+    'summary' => 'example',  // Optional. Event Summary / title 
+    'description' => 'Example description',  // Optional. Event Description 
+    'starts_at' => 'example',  // Optional. Date (and time if not an all day event) that the event starts at (format: 2015-09-15 or 2015-09-15T11:50:00-05:00) 
+    'ends_at' => 'example',  // Optional. Date (and time if not an all day event) that the event ends at (format: 2015-09-15 or 2015-09-15T11:50:00-05:00) 
+    'remind_at' => 'example',  // Optional. Datetime to remind subscribers about the event via email (format: 2015-09-15T11:50:00-05:00) 
+    'subscribers' => '',  // Optional. Array of user id's to subscribe to the event. 
+    'recurring' => '',  // Optional. Array of recurring parrameters - starts_at, frequency, count, until, excluding 
+    'all_day' => '',  // Optional. Is the event a full day event? 
+) ); 
+``` 
+
+### Delete a project calendar event
+[Basecamp API: Calendar Events](https://github.com/basecamp/bcx-api/blob/master/sections/calendar_events.md) 
+
+```php 
+$response = $client->deleteProjectCalendarEvent( array( 
+    'projectId' => 1234567,  // Required. Project id 
+    'eventId' => 1234567,  // Required. Event id 
+) ); 
 ``` 
 
 <!--- END API -->

--- a/src/Basecamp/Resources/service.php
+++ b/src/Basecamp/Resources/service.php
@@ -457,6 +457,460 @@ return array(
                     'required' => false
                 )
             )
+        ),
+        'getCalendars' => array(
+            'httpMethod' => 'GET',
+            'uri' => 'calendars.json',
+            'summary' => 'Get all Calendars' . PHP_EOL . '[Basecamp API: Calendars](https://github.com/basecamp/bcx-api/blob/master/sections/calendars.md)'
+        ),
+        'getCalendar' => array(
+            'httpMethod' => 'GET',
+            'uri' => 'calendars/{calendarId}.json',
+            'summary' => 'Get single Calendar' . PHP_EOL . '[Basecamp API: Calendars](https://github.com/basecamp/bcx-api/blob/master/sections/calendars.md)',
+            'parameters' => array(
+                'calendarId' => array(
+                    'location' => 'uri',
+                    'description' => 'Calendar id',
+                    'type' => 'integer',
+                    'required' => true,
+                )
+            )
+        ),
+        'createCalendar' => array(
+            'httpMethod' => 'POST',
+            'uri' => 'calendars.json',
+            'summary' => 'Create new Calendar' . PHP_EOL . '[Basecamp API: Calendars](https://github.com/basecamp/bcx-api/blob/master/sections/calendars.md)',
+            'parameters' => array(
+                'name' => array(
+                    'location' => 'json',
+                    'type' => 'string',
+                    'required' => true
+                )
+            )
+        ),
+        'updateCalendar' => array(
+            'httpMethod' => 'PUT',
+            'uri' => 'calendars/{calendarId}.json',
+            'summary' => 'Update Calendar' . PHP_EOL . '[Basecamp API: Calendars](https://github.com/basecamp/bcx-api/blob/master/sections/calendars.md)',
+            'parameters' => array(
+                'calendarId' => array(
+                    'location' => 'uri',
+                    'description' => 'Calendar id',
+                    'type' => 'integer',
+                    'required' => true,
+                ),
+                'name' => array(
+                    'location' => 'json',
+                    'type' => 'string',
+                    'required' => true
+                )
+            )
+        ),
+        'deleteCalendar' => array(
+            'httpMethod' => 'DELETE',
+            'uri' => 'calendars/{calendarId}.json',
+            'summary' => 'Delete Calendar' . PHP_EOL . '[Basecamp API: Calendars](https://github.com/basecamp/bcx-api/blob/master/sections/calendars.md)',
+            'parameters' => array(
+                'calendarId' => array(
+                    'location' => 'uri',
+                    'description' => 'Calendar id',
+                    'type' => 'integer',
+                    'required' => true,
+                )
+            )
+        ),
+        'getAllCalendarEvents' => array(
+            'httpMethod' => 'GET',
+            'uri' => 'calendar_events.json',
+            'summary' => 'Get all events' . PHP_EOL . '[Basecamp API: Calendar Events](https://github.com/basecamp/bcx-api/blob/master/sections/calendar_events.md)',
+            'parameters' => array(
+                'start_date' => array(
+                    'location' => 'query',
+                    'description' => 'Will return 6 weeks worth of events after the start date if the end date is not supplied (format: 2015-09-15)',
+                    'type' => 'string'
+                ),
+                'end_date' => array(
+                    'location' => 'query',
+                    'description' => 'Will return 6 weeks worth of events after the start date if the end date is not supplied (format: 2015-09-15)',
+                    'type' => 'string'
+                )
+            )
+        ),
+        'getCalendarEvents' => array(
+            'httpMethod' => 'GET',
+            'uri' => 'calendars/{calendarId}/calendar_events.json',
+            'summary' => 'Get upcoming calendar events' . PHP_EOL . '[Basecamp API: Calendar Events](https://github.com/basecamp/bcx-api/blob/master/sections/calendar_events.md)',
+            'parameters' => array(
+                'calendarId' => array(
+                    'location' => 'uri',
+                    'description' => 'Calendar id',
+                    'type' => 'integer',
+                    'required' => true,
+                ),
+                'start_date' => array(
+                    'location' => 'query',
+                    'description' => 'Will return 6 weeks worth of events after the start date if the end date is not supplied (format: 2015-09-15)',
+                    'type' => 'string'
+                ),
+                'end_date' => array(
+                    'location' => 'query',
+                    'description' => 'Will return 6 weeks worth of events after the start date if the end date is not supplied (format: 2015-09-15)',
+                    'type' => 'string'
+                )
+            )
+        ),
+        'getCalendarEventsPast' => array(
+            'httpMethod' => 'GET',
+            'uri' => 'calendars/{calendarId}/calendar_events/past.json',
+            'summary' => 'Get past calendar events' . PHP_EOL . '[Basecamp API: Calendar Events](https://github.com/basecamp/bcx-api/blob/master/sections/calendar_events.md)',
+            'parameters' => array(
+                'calendarId' => array(
+                    'location' => 'uri',
+                    'description' => 'Calendar id',
+                    'type' => 'integer',
+                    'required' => true,
+                )
+            )
+        ),
+        'getCalendarEvent' => array(
+            'httpMethod' => 'GET',
+            'uri' => 'calendars/{calendarId}/calendar_events/{eventId}.json',
+            'summary' => 'Get single calendar event' . PHP_EOL . '[Basecamp API: Calendar Events](https://github.com/basecamp/bcx-api/blob/master/sections/calendar_events.md)',
+            'parameters' => array(
+                'calendarId' => array(
+                    'location' => 'uri',
+                    'description' => 'Calendar id',
+                    'type' => 'integer',
+                    'required' => true,
+                ),
+                'eventId' => array(
+                    'location' => 'uri',
+                    'description' => 'Event id',
+                    'type' => 'integer',
+                    'required' => true,
+                )
+            )
+        ),
+        'createCalendarEvent' => array(
+            'httpMethod' => 'POST',
+            'uri' => 'calendars/{calendarId}/calendar_events.json',
+            'summary' => 'Create calendar event' . PHP_EOL . '[Basecamp API: Calendar Events](https://github.com/basecamp/bcx-api/blob/master/sections/calendar_events.md)',
+            'parameters' => array(
+                'calendarId' => array(
+                    'location' => 'uri',
+                    'description' => 'Calendar id',
+                    'type' => 'integer',
+                    'required' => true,
+                ),
+                'summary' => array(
+                    'location' => 'json',
+                    'description' => 'Event Summary / title',
+                    'type' => 'string',
+                    'required' => true
+                ),
+                'description' => array(
+                    'location' => 'json',
+                    'description' => 'Event Description',
+                    'type' => 'string'
+                ),
+                'starts_at' => array(
+                    'location' => 'json',
+                    'description' => 'Date (and time if not an all day event) that the event starts at (format: 2015-09-15 or 2015-09-15T11:50:00-05:00)',
+                    'type' => 'string',
+                    'required' => true
+                ),
+                'ends_at' => array(
+                    'location' => 'json',
+                    'description' => 'Date (and time if not an all day event) that the event ends at (format: 2015-09-15 or 2015-09-15T11:50:00-05:00)',
+                    'type' => 'string'
+                ),
+                'remind_at' => array(
+                    'location' => 'json',
+                    'description' => 'Datetime to remind subscribers about the event via email (format: 2015-09-15T11:50:00-05:00)',
+                    'type' => 'string'
+                ),
+                'subscribers' => array(
+                    'location' => 'json',
+                    'description' => 'Array of user id\'s to subscribe to the event.',
+                    'type' => 'array'
+                ),
+                'recurring' => array(
+                    'location' => 'json',
+                    'description' => 'Array of recurring parrameters - starts_at, frequency, count, until, excluding',
+                    'type' => 'array'
+                ),
+                'all_day' => array(
+                    'location' => 'json',
+                    'description' => 'Is the event a full day event?',
+                    'type' => 'boolean'
+                )
+            )
+        ),
+        'updateCalendarEvent' => array(
+            'httpMethod' => 'PUT',
+            'uri' => 'calendars/{calendarId}/calendar_events/{eventId}.json',
+            'summary' => 'Update a calendar event' . PHP_EOL . '[Basecamp API: Calendar Events](https://github.com/basecamp/bcx-api/blob/master/sections/calendar_events.md)',
+            'parameters' => array(
+                'calendarId' => array(
+                    'location' => 'uri',
+                    'description' => 'Calendar id',
+                    'type' => 'integer',
+                    'required' => true,
+                ),
+                'eventId' => array(
+                    'location' => 'uri',
+                    'description' => 'Event id',
+                    'type' => 'integer',
+                    'required' => true,
+                ),
+                'summary' => array(
+                    'location' => 'json',
+                    'description' => 'Event Summary / title',
+                    'type' => 'string'
+                ),
+                'description' => array(
+                    'location' => 'json',
+                    'description' => 'Event Description',
+                    'type' => 'string'
+                ),
+                'starts_at' => array(
+                    'location' => 'json',
+                    'description' => 'Date (and time if not an all day event) that the event starts at (format: 2015-09-15 or 2015-09-15T11:50:00-05:00)',
+                    'type' => 'string'
+                ),
+                'ends_at' => array(
+                    'location' => 'json',
+                    'description' => 'Date (and time if not an all day event) that the event ends at (format: 2015-09-15 or 2015-09-15T11:50:00-05:00)',
+                    'type' => 'string'
+                ),
+                'remind_at' => array(
+                    'location' => 'json',
+                    'description' => 'Datetime to remind subscribers about the event via email (format: 2015-09-15T11:50:00-05:00)',
+                    'type' => 'string'
+                ),
+                'subscribers' => array(
+                    'location' => 'json',
+                    'description' => 'Array of user id\'s to subscribe to the event.',
+                    'type' => 'array'
+                ),
+                'recurring' => array(
+                    'location' => 'json',
+                    'description' => 'Array of recurring parrameters - starts_at, frequency, count, until, excluding',
+                    'type' => 'array'
+                ),
+                'all_day' => array(
+                    'location' => 'json',
+                    'description' => 'Is the event a full day event?',
+                    'type' => 'boolean'
+                )
+            )
+        ),
+        'deleteCalendarEvent' => array(
+            'httpMethod' => 'DELETE',
+            'uri' => 'calendars/{calendarId}/calendar_events/{eventId}.json',
+            'summary' => 'Delete a calendar event' . PHP_EOL . '[Basecamp API: Calendar Events](https://github.com/basecamp/bcx-api/blob/master/sections/calendar_events.md)',
+            'parameters' => array(
+                'calendarId' => array(
+                    'location' => 'uri',
+                    'description' => 'Calendar id',
+                    'type' => 'integer',
+                    'required' => true,
+                ),
+                'eventId' => array(
+                    'location' => 'uri',
+                    'description' => 'Event id',
+                    'type' => 'integer',
+                    'required' => true,
+                )
+            )
+        ),
+        'getProjectCalendarEvents' => array(
+            'httpMethod' => 'GET',
+            'uri' => 'projects/{projectId}/calendar_events.json',
+            'summary' => 'Get upcoming project calendar events' . PHP_EOL . '[Basecamp API: Calendar Events](https://github.com/basecamp/bcx-api/blob/master/sections/calendar_events.md)',
+            'parameters' => array(
+                'projectId' => array(
+                    'location' => 'uri',
+                    'description' => 'Project ID',
+                    'type' => 'integer',
+                    'required' => true,
+                ),
+                'start_date' => array(
+                    'location' => 'query',
+                    'description' => 'Will return 6 weeks worth of events after the start date if the end date is not supplied (format: 2015-09-15)',
+                    'type' => 'string'
+                ),
+                'end_date' => array(
+                    'location' => 'query',
+                    'description' => 'Will return 6 weeks worth of events after the start date if the end date is not supplied (format: 2015-09-15)',
+                    'type' => 'string'
+                )
+            )
+        ),
+        'getProjectCalendarEventsPast' => array(
+            'httpMethod' => 'GET',
+            'uri' => 'projects/{projectId}/calendar_events/past.json',
+            'summary' => 'Get past project calendar events' . PHP_EOL . '[Basecamp API: Calendar Events](https://github.com/basecamp/bcx-api/blob/master/sections/calendar_events.md)',
+            'parameters' => array(
+                'projectId' => array(
+                    'location' => 'uri',
+                    'description' => 'Project ID',
+                    'type' => 'integer',
+                    'required' => true,
+                )
+            )
+        ),
+        'getProjectCalendarEvent' => array(
+            'httpMethod' => 'GET',
+            'uri' => 'projects/{projectId}/calendar_events/{eventId}.json',
+            'summary' => 'Get single project calendar event' . PHP_EOL . '[Basecamp API: Calendar Events](https://github.com/basecamp/bcx-api/blob/master/sections/calendar_events.md)',
+            'parameters' => array(
+                'projectId' => array(
+                    'location' => 'uri',
+                    'description' => 'Project id',
+                    'type' => 'integer',
+                    'required' => true,
+                ),
+                'eventId' => array(
+                    'location' => 'uri',
+                    'description' => 'Event id',
+                    'type' => 'integer',
+                    'required' => true,
+                )
+            )
+        ),
+        'createProjectCalendarEvent' => array(
+            'httpMethod' => 'POST',
+            'uri' => 'projects/{projectId}/calendar_events.json',
+            'summary' => 'Create project calendar event' . PHP_EOL . '[Basecamp API: Calendar Events](https://github.com/basecamp/bcx-api/blob/master/sections/calendar_events.md)',
+            'parameters' => array(
+                'projectId' => array(
+                    'location' => 'uri',
+                    'description' => 'Project id',
+                    'type' => 'integer',
+                    'required' => true,
+                ),
+                'summary' => array(
+                    'location' => 'json',
+                    'description' => 'Event Summary / title',
+                    'type' => 'string',
+                    'required' => true
+                ),
+                'description' => array(
+                    'location' => 'json',
+                    'description' => 'Event Description',
+                    'type' => 'string'
+                ),
+                'starts_at' => array(
+                    'location' => 'json',
+                    'description' => 'Date (and time if not an all day event) that the event starts at (format: 2015-09-15 or 2015-09-15T11:50:00-05:00)',
+                    'type' => 'string',
+                    'required' => true
+                ),
+                'ends_at' => array(
+                    'location' => 'json',
+                    'description' => 'Date (and time if not an all day event) that the event ends at (format: 2015-09-15 or 2015-09-15T11:50:00-05:00)',
+                    'type' => 'string'
+                ),
+                'remind_at' => array(
+                    'location' => 'json',
+                    'description' => 'Datetime to remind subscribers about the event via email (format: 2015-09-15T11:50:00-05:00)',
+                    'type' => 'string'
+                ),
+                'subscribers' => array(
+                    'location' => 'json',
+                    'description' => 'Array of user id\'s to subscribe to the event.',
+                    'type' => 'array'
+                ),
+                'recurring' => array(
+                    'location' => 'json',
+                    'description' => 'Array of recurring parrameters - starts_at, frequency, count, until, excluding',
+                    'type' => 'array'
+                ),
+                'all_day' => array(
+                    'location' => 'json',
+                    'description' => 'Is the event a full day event?',
+                    'type' => 'boolean'
+                )
+            )
+        ),
+        'updateProjectCalendarEvent' => array(
+            'httpMethod' => 'PUT',
+            'uri' => 'projects/{projectId}/calendar_events/{eventId}.json',
+            'summary' => 'Update a project calendar event' . PHP_EOL . '[Basecamp API: Calendar Events](https://github.com/basecamp/bcx-api/blob/master/sections/calendar_events.md)',
+            'parameters' => array(
+                'projectId' => array(
+                    'location' => 'uri',
+                    'description' => 'Project id',
+                    'type' => 'integer',
+                    'required' => true,
+                ),
+                'eventId' => array(
+                    'location' => 'uri',
+                    'description' => 'Event id',
+                    'type' => 'integer',
+                    'required' => true,
+                ),
+                'summary' => array(
+                    'location' => 'json',
+                    'description' => 'Event Summary / title',
+                    'type' => 'string'
+                ),
+                'description' => array(
+                    'location' => 'json',
+                    'description' => 'Event Description',
+                    'type' => 'string'
+                ),
+                'starts_at' => array(
+                    'location' => 'json',
+                    'description' => 'Date (and time if not an all day event) that the event starts at (format: 2015-09-15 or 2015-09-15T11:50:00-05:00)',
+                    'type' => 'string'
+                ),
+                'ends_at' => array(
+                    'location' => 'json',
+                    'description' => 'Date (and time if not an all day event) that the event ends at (format: 2015-09-15 or 2015-09-15T11:50:00-05:00)',
+                    'type' => 'string'
+                ),
+                'remind_at' => array(
+                    'location' => 'json',
+                    'description' => 'Datetime to remind subscribers about the event via email (format: 2015-09-15T11:50:00-05:00)',
+                    'type' => 'string'
+                ),
+                'subscribers' => array(
+                    'location' => 'json',
+                    'description' => 'Array of user id\'s to subscribe to the event.',
+                    'type' => 'array'
+                ),
+                'recurring' => array(
+                    'location' => 'json',
+                    'description' => 'Array of recurring parrameters - starts_at, frequency, count, until, excluding',
+                    'type' => 'array'
+                ),
+                'all_day' => array(
+                    'location' => 'json',
+                    'description' => 'Is the event a full day event?',
+                    'type' => 'boolean'
+                )
+            )
+        ),
+        'deleteProjectCalendarEvent' => array(
+            'httpMethod' => 'DELETE',
+            'uri' => 'projects/{projectId}/calendar_events/{eventId}.json',
+            'summary' => 'Delete a project calendar event' . PHP_EOL . '[Basecamp API: Calendar Events](https://github.com/basecamp/bcx-api/blob/master/sections/calendar_events.md)',
+            'parameters' => array(
+                'projectId' => array(
+                    'location' => 'uri',
+                    'description' => 'Project id',
+                    'type' => 'integer',
+                    'required' => true,
+                ),
+                'eventId' => array(
+                    'location' => 'uri',
+                    'description' => 'Event id',
+                    'type' => 'integer',
+                    'required' => true,
+                )
+            )
         )
     )
 );

--- a/tests/Basecamp/Test/BasecampClientTest.php
+++ b/tests/Basecamp/Test/BasecampClientTest.php
@@ -540,4 +540,191 @@ class BasecampClientTest extends \Guzzle\Tests\GuzzleTestCase
         $this->assertSame(67890, $response[1]['id']);
         $this->assertSame("Bar Associates", $response[1]['name']);
     }
+
+    public function testGetCalendars()
+    {
+        $client = $this->getServiceBuilder()->get('basecamp');
+        $this->setMockResponse($client, array(
+            'get_calendars'
+        ));
+        $response = $client->getCalendars();
+        $this->assertInternalType('array', $response);
+        $this->assertArrayHasKey(0, $response);
+        $this->assertArrayHasKey('id', $response[0]);
+        $this->assertSame(1, $response[0]['id']);
+    }
+
+    public function testGetCalendar()
+    {
+        $client = $this->getServiceBuilder()->get('basecamp');
+        $this->setMockResponse($client, array(
+            'get_calendar'
+        ));
+        $response = $client->getCalendar(array(
+            'calendarId' => 1
+        ));
+        $this->assertInternalType('array', $response);
+        $this->assertArrayHasKey('id', $response);
+        $this->assertSame(1, $response['id']);
+    }
+
+    public function testCreateCalendar()
+    {
+        $client = $this->getServiceBuilder()->get('basecamp');
+        $this->setMockResponse($client, array(
+            'create_calendar'
+        ));
+        $calendarName = 'Mock Calendar';
+        $response = $client->createCalendar(array(
+            'name'        => $calendarName,
+        ));
+        $this->assertInternalType('array', $response);
+        $this->assertArrayHasKey('id', $response);
+        $this->assertArrayHasKey('name', $response);
+        $this->assertSame($calendarName, $response['name']);
+    }
+
+    public function testGetAllCalendarEvents()
+    {
+        $client = $this->getServiceBuilder()->get('basecamp');
+        $this->setMockResponse($client, array(
+            'get_all_calendar_events'
+        ));
+        $response = $client->getAllCalendarEvents();
+        $this->assertInternalType('array', $response);
+        $this->assertArrayHasKey(0, $response);
+        $this->assertArrayHasKey('id', $response[0]);
+        $this->assertSame(1, $response[0]['id']);
+    }
+
+    public function testGetCalendarEvents()
+    {
+        $client = $this->getServiceBuilder()->get('basecamp');
+        $this->setMockResponse($client, array(
+            'get_calendar_events'
+        ));
+        $response = $client->getCalendarEvents(array(
+            'calendarId' => 1
+        ));
+        $this->assertInternalType('array', $response);
+        $this->assertArrayHasKey(0, $response);
+        $this->assertArrayHasKey('id', $response[0]);
+        $this->assertSame(1, $response[0]['id']);
+    }
+
+    public function testGetCalendarEventsPast()
+    {
+        $client = $this->getServiceBuilder()->get('basecamp');
+        $this->setMockResponse($client, array(
+            'get_calendar_events_past'
+        ));
+        $response = $client->getCalendarEvents(array(
+            'calendarId' => 1
+        ));
+        $this->assertInternalType('array', $response);
+        $this->assertArrayHasKey(0, $response);
+        $this->assertArrayHasKey('id', $response[0]);
+        $this->assertSame(1, $response[0]['id']);
+    }
+
+    public function testGetCalendarEvent()
+    {
+        $client = $this->getServiceBuilder()->get('basecamp');
+        $this->setMockResponse($client, array(
+            'get_calendar_event'
+        ));
+        $response = $client->getCalendarEvent(array(
+            'calendarId' => 1,
+            'eventId' => 1
+        ));
+        $this->assertInternalType('array', $response);
+        $this->assertArrayHasKey('id', $response);
+        $this->assertSame(1, $response['id']);
+    }
+
+    public function testCreateCalendarEvent()
+    {
+        $client = $this->getServiceBuilder()->get('basecamp');
+        $this->setMockResponse($client, array(
+            'create_calendar_event'
+        ));
+        $eventSummary = 'Mock Event';
+        $eventStartsAt = '2015-09-17';
+        $response = $client->createCalendarEvent(array(
+            'calendarId' => 1,
+            'summary' => $eventSummary,
+            'starts_at' => $eventStartsAt,
+            'all_day' => true
+        ));
+        $this->assertInternalType('array', $response);
+        $this->assertArrayHasKey('id', $response);
+        $this->assertArrayHasKey('summary', $response);
+        $this->assertSame($eventSummary, $response['summary']);
+    }
+
+    public function testGetProjectCalendarEvents()
+    {
+        $client = $this->getServiceBuilder()->get('basecamp');
+        $this->setMockResponse($client, array(
+            'get_project_calendar_events'
+        ));
+        $response = $client->getProjectCalendarEvents(array(
+            'projectId' => 1
+        ));
+        $this->assertInternalType('array', $response);
+        $this->assertArrayHasKey(0, $response);
+        $this->assertArrayHasKey('id', $response[0]);
+        $this->assertSame(1, $response[0]['id']);
+    }
+
+    public function testGetProjectCalendarEventsPast()
+    {
+        $client = $this->getServiceBuilder()->get('basecamp');
+        $this->setMockResponse($client, array(
+            'get_project_calendar_events_past'
+        ));
+        $response = $client->getProjectCalendarEvents(array(
+            'projectId' => 1
+        ));
+        $this->assertInternalType('array', $response);
+        $this->assertArrayHasKey(0, $response);
+        $this->assertArrayHasKey('id', $response[0]);
+        $this->assertSame(1, $response[0]['id']);
+    }
+
+    public function testGetProjectCalendarEvent()
+    {
+        $client = $this->getServiceBuilder()->get('basecamp');
+        $this->setMockResponse($client, array(
+            'get_project_calendar_event'
+        ));
+        $response = $client->getProjectCalendarEvent(array(
+            'projectId' => 1,
+            'eventId' => 1
+        ));
+        $this->assertInternalType('array', $response);
+        $this->assertArrayHasKey('id', $response);
+        $this->assertSame(1, $response['id']);
+    }
+
+    public function testCreateProjectCalendarEvent()
+    {
+        $client = $this->getServiceBuilder()->get('basecamp');
+        $this->setMockResponse($client, array(
+            'create_project_calendar_event'
+        ));
+        $eventSummary = 'Mock Event';
+        $eventStartsAt = '2015-09-17';
+        $response = $client->createProjectCalendarEvent(array(
+            'projectId' => 1,
+            'summary' => $eventSummary,
+            'starts_at' => $eventStartsAt,
+            'all_day' => true
+        ));
+        $this->assertInternalType('array', $response);
+        $this->assertArrayHasKey('id', $response);
+        $this->assertArrayHasKey('summary', $response);
+        $this->assertSame($eventSummary, $response['summary']);
+    }
+
 }

--- a/tests/mock/create_calendar
+++ b/tests/mock/create_calendar
@@ -1,0 +1,19 @@
+HTTP/1.1 201 Created
+Server: nginx
+Date: Wed, 16 Sep 2015 14:06:33 GMT
+Content-Type: application/json; charset=utf-8
+Transfer-Encoding: chunked
+Connection: keep-alive
+Status: 201 Created
+X-Frame-Options: SAMEORIGIN
+X-XSS-Protection: 1; mode=block
+X-Content-Type-Options: nosniff
+X-UA-Compatible: chrome=1
+X-XHR-Current-Location: /1/api/v1/projects/calendars/1.json
+X-Asset-Paths: {"application.js":"application-da0397a39fc2aab6a0416fcf6635e0c1.js","application.css":"application-b1d06c890745ca8ff30e9adb7b6f5395.css"}
+Last-Modified: Tue, 04 Jun 2013 07:12:52 GMT
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: d8848209-ee11-484a-ade7-5e8c56a4c1a1
+X-Runtime: 0.348645
+
+{"id":1,"name":"Mock Calendar","updated_at":"2015-08-07T12:50:44.000Z","color":"009900","url":"https://basecamp.com/99999999/api/v1/calendars/1.json","app_url":"https://basecamp.com/99999999/calendars/1"}

--- a/tests/mock/create_calendar_event
+++ b/tests/mock/create_calendar_event
@@ -1,0 +1,19 @@
+HTTP/1.1 201 Created
+Server: nginx
+Date: Wed, 16 Sep 2015 14:06:33 GMT
+Content-Type: application/json; charset=utf-8
+Transfer-Encoding: chunked
+Connection: keep-alive
+Status: 201 Created
+X-Frame-Options: SAMEORIGIN
+X-XSS-Protection: 1; mode=block
+X-Content-Type-Options: nosniff
+X-UA-Compatible: chrome=1
+X-XHR-Current-Location: /1/api/v1/calendars/1/calendar_events/1.json
+X-Asset-Paths: {"application.js":"application-da0397a39fc2aab6a0416fcf6635e0c1.js","application.css":"application-b1d06c890745ca8ff30e9adb7b6f5395.css"}
+Last-Modified: Tue, 04 Jun 2013 07:12:52 GMT
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: d8848209-ee11-484a-ade7-5e8c56a4c1a1
+X-Runtime: 0.348645
+
+{"id":1,"created_at":"2015-08-11T07:35:43.000Z","updated_at":"2015-09-16T10:44:15.000Z","summary":"Mock Event","description":"Testing","private":false,"trashed":false,"all_day":true,"starts_at":"2015-09-17","ends_at":"2015-09-23","remind_at":"2015-09-17T06:00:00.000Z","url":"https://basecamp.com/99999999/api/v1/calendars/1/calendar_events/1.json","app_url":"https://basecamp.com/99999999/calendars/1/calendar_events/1","comments_count":0}

--- a/tests/mock/create_project_calendar_event
+++ b/tests/mock/create_project_calendar_event
@@ -1,0 +1,19 @@
+HTTP/1.1 201 Created
+Server: nginx
+Date: Wed, 16 Sep 2015 14:06:33 GMT
+Content-Type: application/json; charset=utf-8
+Transfer-Encoding: chunked
+Connection: keep-alive
+Status: 201 Created
+X-Frame-Options: SAMEORIGIN
+X-XSS-Protection: 1; mode=block
+X-Content-Type-Options: nosniff
+X-UA-Compatible: chrome=1
+X-XHR-Current-Location: /1/api/v1/projects/1/calendar_events/1.json
+X-Asset-Paths: {"application.js":"application-da0397a39fc2aab6a0416fcf6635e0c1.js","application.css":"application-b1d06c890745ca8ff30e9adb7b6f5395.css"}
+Last-Modified: Tue, 04 Jun 2013 07:12:52 GMT
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: d8848209-ee11-484a-ade7-5e8c56a4c1a1
+X-Runtime: 0.348645
+
+{"id":1,"created_at":"2015-08-11T07:35:43.000Z","updated_at":"2015-09-16T10:44:15.000Z","summary":"Mock Event","description":"Testing","private":false,"trashed":false,"all_day":true,"starts_at":"2015-09-17","ends_at":"2015-09-23","remind_at":"2015-09-17T06:00:00.000Z","url":"https://basecamp.com/99999999/api/v1/projects/1/calendar_events/1.json","app_url":"https://basecamp.com/99999999/projects/1/calendar_events/1","comments_count":0}

--- a/tests/mock/get_all_calendar_events
+++ b/tests/mock/get_all_calendar_events
@@ -1,0 +1,19 @@
+HTTP/1.1 200 OK
+Server: nginx
+Date: Wed, 16 Sep 2015 14:06:33 GMT
+Content-Type: application/json; charset=utf-8
+Transfer-Encoding: chunked
+Connection: keep-alive
+Status: 200 OK
+X-Frame-Options: SAMEORIGIN
+X-XSS-Protection: 1; mode=block
+X-Content-Type-Options: nosniff
+X-UA-Compatible: chrome=1
+X-XHR-Current-Location: /1/api/v1/calendar_events.json
+X-Asset-Paths: {"application.js":"application-da0397a39fc2aab6a0416fcf6635e0c1.js","application.css":"application-b1d06c890745ca8ff30e9adb7b6f5395.css"}
+Last-Modified: Tue, 04 Jun 2013 07:12:52 GMT
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: d8848209-ee11-484a-ade7-5e8c56a4c1a1
+X-Runtime: 0.348645
+
+[{"id":1,"created_at":"2015-08-11T07:35:43.000Z","updated_at":"2015-09-16T10:44:15.000Z","summary":"Mock Event","description":"Testing","private":false,"trashed":false,"all_day":true,"starts_at":"2015-09-17","ends_at":"2015-09-23","remind_at":"2015-09-17T06:00:00.000Z","url":"https://basecamp.com/99999999/api/v1/calendars/1/calendar_events/1.json","app_url":"https://basecamp.com/99999999/calendars/1/calendar_events/1","bucket":{"type":"Calendar","id":1,"name":"Mock Calendar","color":"46647c","url":"https://basecamp.com/99999999/api/v1/calendars/1.json","app_url":"https://basecamp.com/99999999/calendars/1"},"comments_count":0}]

--- a/tests/mock/get_calendar
+++ b/tests/mock/get_calendar
@@ -1,0 +1,19 @@
+HTTP/1.1 200 OK
+Server: nginx
+Date: Wed, 16 Sep 2015 14:06:33 GMT
+Content-Type: application/json; charset=utf-8
+Transfer-Encoding: chunked
+Connection: keep-alive
+Status: 200 OK
+X-Frame-Options: SAMEORIGIN
+X-XSS-Protection: 1; mode=block
+X-Content-Type-Options: nosniff
+X-UA-Compatible: chrome=1
+X-XHR-Current-Location: /1/api/v1/calendars/1.json
+X-Asset-Paths: {"application.js":"application-da0397a39fc2aab6a0416fcf6635e0c1.js","application.css":"application-b1d06c890745ca8ff30e9adb7b6f5395.css"}
+Last-Modified: Tue, 04 Jun 2013 07:12:52 GMT
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: d8848209-ee11-484a-ade7-5e8c56a4c1a1
+X-Runtime: 0.348645
+
+{"id":1,"name":"Mock Calendar","updated_at":"2015-08-07T12:50:44.000Z","color":"009900","url":"https://basecamp.com/99999999/api/v1/calendars/1.json","app_url":"https://basecamp.com/99999999/calendars/1"}

--- a/tests/mock/get_calendar_event
+++ b/tests/mock/get_calendar_event
@@ -1,0 +1,19 @@
+HTTP/1.1 200 OK
+Server: nginx
+Date: Wed, 16 Sep 2015 14:06:33 GMT
+Content-Type: application/json; charset=utf-8
+Transfer-Encoding: chunked
+Connection: keep-alive
+Status: 200 OK
+X-Frame-Options: SAMEORIGIN
+X-XSS-Protection: 1; mode=block
+X-Content-Type-Options: nosniff
+X-UA-Compatible: chrome=1
+X-XHR-Current-Location: /1/api/v1/calendars/1/calendar_events/1.json
+X-Asset-Paths: {"application.js":"application-da0397a39fc2aab6a0416fcf6635e0c1.js","application.css":"application-b1d06c890745ca8ff30e9adb7b6f5395.css"}
+Last-Modified: Tue, 04 Jun 2013 07:12:52 GMT
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: d8848209-ee11-484a-ade7-5e8c56a4c1a1
+X-Runtime: 0.348645
+
+{"id":1,"created_at":"2015-08-11T07:35:43.000Z","updated_at":"2015-09-16T10:44:15.000Z","summary":"Mock Event","description":"Testing","private":false,"trashed":false,"all_day":true,"starts_at":"2015-09-17","ends_at":"2015-09-23","remind_at":"2015-09-17T06:00:00.000Z","url":"https://basecamp.com/99999999/api/v1/calendars/1/calendar_events/1.json","app_url":"https://basecamp.com/99999999/calendars/1/calendar_events/1","comments_count":0}

--- a/tests/mock/get_calendar_events
+++ b/tests/mock/get_calendar_events
@@ -1,0 +1,19 @@
+HTTP/1.1 200 OK
+Server: nginx
+Date: Wed, 16 Sep 2015 14:06:33 GMT
+Content-Type: application/json; charset=utf-8
+Transfer-Encoding: chunked
+Connection: keep-alive
+Status: 200 OK
+X-Frame-Options: SAMEORIGIN
+X-XSS-Protection: 1; mode=block
+X-Content-Type-Options: nosniff
+X-UA-Compatible: chrome=1
+X-XHR-Current-Location: /1/api/v1/calendars/1/calendar_events.json
+X-Asset-Paths: {"application.js":"application-da0397a39fc2aab6a0416fcf6635e0c1.js","application.css":"application-b1d06c890745ca8ff30e9adb7b6f5395.css"}
+Last-Modified: Tue, 04 Jun 2013 07:12:52 GMT
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: d8848209-ee11-484a-ade7-5e8c56a4c1a1
+X-Runtime: 0.348645
+
+[{"id":1,"created_at":"2015-08-11T07:35:43.000Z","updated_at":"2015-09-16T10:44:15.000Z","summary":"Mock Event","description":"Testing","private":false,"trashed":false,"all_day":true,"starts_at":"2015-09-17","ends_at":"2015-09-23","remind_at":"2015-09-17T06:00:00.000Z","url":"https://basecamp.com/99999999/api/v1/calendars/1/calendar_events/1.json","app_url":"https://basecamp.com/99999999/calendars/1/calendar_events/1","comments_count":0}]

--- a/tests/mock/get_calendar_events_past
+++ b/tests/mock/get_calendar_events_past
@@ -1,0 +1,19 @@
+HTTP/1.1 200 OK
+Server: nginx
+Date: Wed, 16 Sep 2015 14:06:33 GMT
+Content-Type: application/json; charset=utf-8
+Transfer-Encoding: chunked
+Connection: keep-alive
+Status: 200 OK
+X-Frame-Options: SAMEORIGIN
+X-XSS-Protection: 1; mode=block
+X-Content-Type-Options: nosniff
+X-UA-Compatible: chrome=1
+X-XHR-Current-Location: /1/api/v1/calendars/1/calendar_events/past.json
+X-Asset-Paths: {"application.js":"application-da0397a39fc2aab6a0416fcf6635e0c1.js","application.css":"application-b1d06c890745ca8ff30e9adb7b6f5395.css"}
+Last-Modified: Tue, 04 Jun 2013 07:12:52 GMT
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: d8848209-ee11-484a-ade7-5e8c56a4c1a1
+X-Runtime: 0.348645
+
+[{"id":1,"created_at":"2015-08-11T07:35:43.000Z","updated_at":"2015-09-16T10:44:15.000Z","summary":"Mock Event","description":"Testing","private":false,"trashed":false,"all_day":true,"starts_at":"2015-09-17","ends_at":"2015-09-23","remind_at":"2015-09-17T06:00:00.000Z","url":"https://basecamp.com/99999999/api/v1/calendars/1/calendar_events/1.json","app_url":"https://basecamp.com/99999999/calendars/1/calendar_events/1","comments_count":0}]

--- a/tests/mock/get_calendars
+++ b/tests/mock/get_calendars
@@ -1,0 +1,19 @@
+HTTP/1.1 200 OK
+Server: nginx
+Date: Wed, 16 Sep 2015 14:06:33 GMT
+Content-Type: application/json; charset=utf-8
+Transfer-Encoding: chunked
+Connection: keep-alive
+Status: 200 OK
+X-Frame-Options: SAMEORIGIN
+X-XSS-Protection: 1; mode=block
+X-Content-Type-Options: nosniff
+X-UA-Compatible: chrome=1
+X-XHR-Current-Location: /1/api/v1/projects/calendars.json
+X-Asset-Paths: {"application.js":"application-da0397a39fc2aab6a0416fcf6635e0c1.js","application.css":"application-b1d06c890745ca8ff30e9adb7b6f5395.css"}
+Last-Modified: Tue, 04 Jun 2013 07:12:52 GMT
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: d8848209-ee11-484a-ade7-5e8c56a4c1a1
+X-Runtime: 0.348645
+
+[{"id":1,"name":"Mock Calendar","updated_at":"2015-08-07T12:50:44.000Z","color":"009900","url":"https://basecamp.com/99999999/api/v1/calendars/1.json","app_url":"https://basecamp.com/99999999/calendars/1"}]

--- a/tests/mock/get_project_calendar_event
+++ b/tests/mock/get_project_calendar_event
@@ -1,0 +1,19 @@
+HTTP/1.1 200 OK
+Server: nginx
+Date: Wed, 16 Sep 2015 14:06:33 GMT
+Content-Type: application/json; charset=utf-8
+Transfer-Encoding: chunked
+Connection: keep-alive
+Status: 200 OK
+X-Frame-Options: SAMEORIGIN
+X-XSS-Protection: 1; mode=block
+X-Content-Type-Options: nosniff
+X-UA-Compatible: chrome=1
+X-XHR-Current-Location: /1/api/v1/projects/1/calendar_events/1.json
+X-Asset-Paths: {"application.js":"application-da0397a39fc2aab6a0416fcf6635e0c1.js","application.css":"application-b1d06c890745ca8ff30e9adb7b6f5395.css"}
+Last-Modified: Tue, 04 Jun 2013 07:12:52 GMT
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: d8848209-ee11-484a-ade7-5e8c56a4c1a1
+X-Runtime: 0.348645
+
+{"id":1,"created_at":"2015-08-11T07:35:43.000Z","updated_at":"2015-09-16T10:44:15.000Z","summary":"Mock Event","description":"Testing","private":false,"trashed":false,"all_day":true,"starts_at":"2015-09-17","ends_at":"2015-09-23","remind_at":"2015-09-17T06:00:00.000Z","url":"https://basecamp.com/99999999/api/v1/projects/1/calendar_events/1.json","app_url":"https://basecamp.com/99999999/projects/1/calendar_events/1","comments_count":0}

--- a/tests/mock/get_project_calendar_events
+++ b/tests/mock/get_project_calendar_events
@@ -1,0 +1,19 @@
+HTTP/1.1 200 OK
+Server: nginx
+Date: Wed, 16 Sep 2015 14:06:33 GMT
+Content-Type: application/json; charset=utf-8
+Transfer-Encoding: chunked
+Connection: keep-alive
+Status: 200 OK
+X-Frame-Options: SAMEORIGIN
+X-XSS-Protection: 1; mode=block
+X-Content-Type-Options: nosniff
+X-UA-Compatible: chrome=1
+X-XHR-Current-Location: /1/api/v1/projects/1/calendar_events.json
+X-Asset-Paths: {"application.js":"application-da0397a39fc2aab6a0416fcf6635e0c1.js","application.css":"application-b1d06c890745ca8ff30e9adb7b6f5395.css"}
+Last-Modified: Tue, 04 Jun 2013 07:12:52 GMT
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: d8848209-ee11-484a-ade7-5e8c56a4c1a1
+X-Runtime: 0.348645
+
+[{"id":1,"created_at":"2015-08-11T07:35:43.000Z","updated_at":"2015-09-16T10:44:15.000Z","summary":"Mock Event","description":"Testing","private":false,"trashed":false,"all_day":true,"starts_at":"2015-09-17","ends_at":"2015-09-23","remind_at":"2015-09-17T06:00:00.000Z","url":"https://basecamp.com/99999999/api/v1/projects/1/calendar_events/1.json","app_url":"https://basecamp.com/99999999/projects/1/calendar_events/1","comments_count":0}]

--- a/tests/mock/get_project_calendar_events_past
+++ b/tests/mock/get_project_calendar_events_past
@@ -1,0 +1,19 @@
+HTTP/1.1 200 OK
+Server: nginx
+Date: Wed, 16 Sep 2015 14:06:33 GMT
+Content-Type: application/json; charset=utf-8
+Transfer-Encoding: chunked
+Connection: keep-alive
+Status: 200 OK
+X-Frame-Options: SAMEORIGIN
+X-XSS-Protection: 1; mode=block
+X-Content-Type-Options: nosniff
+X-UA-Compatible: chrome=1
+X-XHR-Current-Location: /1/api/v1/projects/1/calendar_events/past.json
+X-Asset-Paths: {"application.js":"application-da0397a39fc2aab6a0416fcf6635e0c1.js","application.css":"application-b1d06c890745ca8ff30e9adb7b6f5395.css"}
+Last-Modified: Tue, 04 Jun 2013 07:12:52 GMT
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: d8848209-ee11-484a-ade7-5e8c56a4c1a1
+X-Runtime: 0.348645
+
+[{"id":1,"created_at":"2015-08-11T07:35:43.000Z","updated_at":"2015-09-16T10:44:15.000Z","summary":"Mock Event","description":"Testing","private":false,"trashed":false,"all_day":true,"starts_at":"2015-09-17","ends_at":"2015-09-23","remind_at":"2015-09-17T06:00:00.000Z","url":"https://basecamp.com/99999999/api/v1/projects/1/calendar_events/1.json","app_url":"https://basecamp.com/99999999/projects/1/calendar_events/1","comments_count":0}]


### PR DESCRIPTION
I've been doing some work with basecamp calendars recently, and found this sdk pretty useful (so thanks!).

Here's the work I've added for calendar endpoints, and project calendar endpoints. There is quite a lot, but I figured it'd be better implementing the full calendar scope into this while I was at it.

Also added tests and updated the README documentation file.