### PR TITLE
variable mismatch fix

### DIFF
--- a/src/Basecamp/Resources/service.php
+++ b/src/Basecamp/Resources/service.php
@@ -29,7 +29,7 @@ return array(
         ),
         'getDocumentsByProject' => array(
             'httpMethod' => 'GET',
-            'uri' => 'projects/{id}/documents.json',
+            'uri' => 'projects/{projectId}/documents.json',
             'summary'   => 'Get all Documents' . PHP_EOL . '[Basecamp API: Documents](https://github.com/basecamp/bcx-api/blob/master/sections/documents.md)',
             'parameters' => array(
                 'projectId' => array(


### PR DESCRIPTION
simple {id} to {projectId} in /src/basecamp/resources/service.php:32