### PR TITLE
Adds missing unit test coverage section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -569,6 +569,19 @@ $response = $client->deleteProjectCalendarEvent( array(
 ) ); 
 ``` 
 
+### Unit Test Coverage 
+
+The following service operations are not (yet) covered by unit tests:
+
+* updateTodo 
+* grantAccess 
+* updateCalendar 
+* deleteCalendar 
+* updateCalendarEvent 
+* deleteCalendarEvent 
+* updateProjectCalendarEvent 
+* deleteProjectCalendarEvent 
+
 <!--- END API -->
 
 [basecamp]: https://basecamp.com/

--- a/tests/Basecamp/Test/BasecampClientTest.php
+++ b/tests/Basecamp/Test/BasecampClientTest.php
@@ -31,6 +31,19 @@ class BasecampClientTest extends \Guzzle\Tests\GuzzleTestCase
     /**
      * @expectedException InvalidArgumentException
      */
+    public function testFactoryInitializesClientWithNoUserOrPassword()
+    {
+        $client = BasecampClient::factory(array(
+            'user_id'     => '999999999',
+            'version'     => 'v2',
+            'app_name'    => 'Fake',
+            'app_contact' => 'test@fake.com'
+        ));
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
     public function testFactoryInitializesClientWithInvalidAuth()
     {
         $client = BasecampClient::factory(array(
@@ -490,19 +503,7 @@ class BasecampClientTest extends \Guzzle\Tests\GuzzleTestCase
         $this->assertSame(149087659, $response[0]['id']);
     }
 
-    public function testGetCurrentPerson()
-    {
-        $client = $this->getServiceBuilder()->get('basecamp');
-        $this->setMockResponse($client, array(
-            'get_person'
-        ));
-        $response = $client->getCurrentUser();
-        $this->assertInternalType('array', $response);
-        $this->assertArrayHasKey('id', $response);
-        $this->assertSame(149087659, $response['id']);
-    }
-
-    public function testGetSpecificPerson()
+    public function testGetSpecificUser()
     {
         $client = $this->getServiceBuilder()->get('basecamp');
         $this->setMockResponse($client, array(


### PR DESCRIPTION
After my previous PR I noticed that `testGetCurrentPerson` is a duplicate test of `testGetCurrentUser`, so have removed that.

I've also added a test to cover the only untested line of code (code coverage is now showing 100%).

However, code coverage being at 100% doesn't represent that every service operation has been unit tested, so I've also added a quick summary to the `README` which tells you which service operation that hasn't been covered by a unit test.

Obviously the ideal situation is that we write unit tests to cover these services, but I figure this at least makes it visible which ones still need written.

Let me know what you think
